### PR TITLE
Allow components to be required at run-time

### DIFF
--- a/cosmos.js
+++ b/cosmos.js
@@ -11,6 +11,7 @@ _.extend(Cosmos, {
   mixins: {},
   components: {},
   transitions: {},
+  componentLookups: [],
   start: function(options) {
     return new this.Router(options);
   },
@@ -23,6 +24,19 @@ _.extend(Cosmos, {
     }
   },
   getComponentByName: function(name) {
+    // The order of calling the lookups is last to first registered
+    var i = this.componentLookups.length,
+        componentFound;
+    while (--i >= 0) {
+      // The context of the callback is irrelevant for now
+      componentFound = this.componentLookups[i].call(this, name);
+      if (componentFound) {
+        return componentFound;
+      }
+    }
     return this.components[name];
+  },
+  registerComponentLookup: function(callback) {
+    this.componentLookups.push(callback);
   }
 });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cosmos-js",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "Data exploration framework",
   "repository": {
     "type": "git",

--- a/specs/cosmos-spec.js
+++ b/specs/cosmos-spec.js
@@ -27,6 +27,39 @@ describe("Cosmos", function() {
     expect(Cosmos.getComponentByName('FakeComponent')).toBe(FakeComponent);
   });
 
+  it("should draw its components from registered lookup callback", function() {
+    var FakeComponent = {};
+    Cosmos.registerComponentLookup(function(name) {
+      expect(name).toBe('FakeComponent');
+      return FakeComponent;
+    });
+    expect(Cosmos.getComponentByName('FakeComponent')).toBe(FakeComponent);
+    // Revert Cosmos to initial state
+    Cosmos.componentLookups = [];
+  });
+
+  it("should prefer components from lookups registered last", function() {
+    var namespace1 = {
+      FakeComponent: {},
+      FakerComponent: {}
+    };
+    var namespace2 = {
+      FakeComponent: {}
+    };
+    Cosmos.registerComponentLookup(function(name) {
+      return namespace1[name];
+    });
+    Cosmos.registerComponentLookup(function(name) {
+      return namespace2[name];
+    });
+    expect(Cosmos.getComponentByName('FakeComponent'))
+          .toBe(namespace2.FakeComponent);
+    expect(Cosmos.getComponentByName('FakerComponent'))
+          .toBe(namespace1.FakerComponent);
+    // Revert Cosmos to initial state
+    Cosmos.componentLookups = [];
+  });
+
   it("should instantiate correct Component", function() {
     var fakeComponentInstance = {};
     Cosmos.components.FakeComponent = jasmine.createSpy('FakeComponent')


### PR DESCRIPTION
Instead of having to be registered in the global Cosmos.components namespace
- [ ] Allow registering component search callback (`registerComponent...`)
