### PR TITLE
Removed deprecated lodash.isarray

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "karma-sinon-chai": "^1.2.3",
     "karma-webpack": "^1.8.0",
     "lcov-result-merger": "^1.2.0",
-    "lerna": "^2.0.0-beta.30",
+    "lerna": "2.0.0-beta.30",
     "less": "^2.7.1",
     "less-loader": "^2.2.3",
     "mocha": "^3.0.2",

--- a/packages/react-cosmos-utils/package.json
+++ b/packages/react-cosmos-utils/package.json
@@ -9,7 +9,6 @@
   ],
   "main": "lib/index.js",
   "dependencies": {
-    "lodash.isarray": "^4.0.0",
     "lodash.isplainobject": "^4.0.6"
   }
 }

--- a/packages/react-cosmos-utils/src/unserializable-parts.js
+++ b/packages/react-cosmos-utils/src/unserializable-parts.js
@@ -1,5 +1,4 @@
 import isPlainObject from 'lodash.isplainobject';
-import isArray from 'lodash.isarray';
 
 const isSerializable = (obj) => {
   if (
@@ -13,7 +12,7 @@ const isSerializable = (obj) => {
   }
 
   if (!isPlainObject(obj) &&
-      !isArray(obj)) {
+      !Array.isArray(obj)) {
     return false;
   }
 


### PR DESCRIPTION
npm WARN deprecated lodash.isarray@4.0.0: This package is deprecated. Use Array.isArray.