### PR TITLE
Add user webpack config validation

### DIFF
--- a/packages/react-cosmos-webpack/package.json
+++ b/packages/react-cosmos-webpack/package.json
@@ -18,6 +18,7 @@
     "glob": "^7.1.1",
     "json-loader": "^0.5.4",
     "loader-utils": "^0.2.16",
+    "lodash.omit": "^4.5.0",
     "react-cosmos": "^2.0.0-beta.5",
     "react-cosmos-utils": "^2.0.0-beta.4",
     "react-cosmos-voyager": "^2.0.0-beta.5",

--- a/packages/react-cosmos-webpack/src/__tests__/webpack-config.js
+++ b/packages/react-cosmos-webpack/src/__tests__/webpack-config.js
@@ -59,30 +59,6 @@ describe('without hmr', () => {
     webpackConfig = getWebpackConfig(userWebpackConfig, cosmosConfigPath);
   });
 
-  test('choose `loaders` or `rules` from user config', () => {
-    const userRule = { foo: 'bar' };
-
-    webpackConfig = getWebpackConfig(
-      {
-        module: {
-          rules: [userRule]
-        }
-      },
-      cosmosConfigPath
-    );
-    expect(webpackConfig.module.rules[0]).toEqual(userRule);
-
-    webpackConfig = getWebpackConfig(
-      {
-        module: {
-          loaders: [userRule]
-        }
-      },
-      cosmosConfigPath
-    );
-    expect(webpackConfig.module.loaders[0]).toEqual(userRule);
-  });
-
   test('keeps user rules', () => {
     expect(webpackConfig.rules).toBe(userWebpackConfig.rules);
   });
@@ -198,5 +174,50 @@ describe('with absolute paths', () => {
     mockCosmosConfig.globalImports.forEach(globalImport => {
       expect(webpackConfig.entry).toContain(globalImport);
     });
+  });
+});
+
+describe('webpack config basic', () => {
+  test('choose `loaders` or `rules` from user config', () => {
+    const userRule = { foo: 'bar' };
+
+    webpackConfig = getWebpackConfig(
+      {
+        module: {
+          rules: [userRule]
+        }
+      },
+      cosmosConfigPath
+    );
+    expect(webpackConfig.module.rules[0]).toEqual(userRule);
+
+    webpackConfig = getWebpackConfig(
+      {
+        module: {
+          loaders: [userRule]
+        }
+      },
+      cosmosConfigPath
+    );
+    expect(webpackConfig.module.loaders[0]).toEqual(userRule);
+  });
+
+  test('passing user data to module config', () => {
+    const additionalOption = {
+      something: 'foo',
+    };
+    const userRule = { foo: 'bar' };
+    webpackConfig = getWebpackConfig(
+      {
+        module: {
+          additionalOption,
+          rules: [userRule],
+        }
+      },
+      cosmosConfigPath
+    );
+
+    expect(webpackConfig.module.additionalOption).toEqual(additionalOption);
+    expect(webpackConfig.module.rules[0]).toEqual(userRule);
   });
 });

--- a/packages/react-cosmos-webpack/src/__tests__/webpack-config.js
+++ b/packages/react-cosmos-webpack/src/__tests__/webpack-config.js
@@ -46,6 +46,23 @@ beforeEach(() => {
   getWebpackConfig = require('../webpack-config').default;
 });
 
+describe('user config validation', () => {
+  beforeEach(() => {
+    mockCosmosConfig = {
+      componentPaths: ['src/components'],
+      fixturePaths: ['test/fixtures'],
+      ignore: [],
+      globalImports: ['./global.css'],
+    };
+  });
+
+  test('should throw an exception if `rules` passed', () => {
+    expect(() => {
+      getWebpackConfig({ module: { rules: {} } }, cosmosConfigPath);
+    }).toThrow();
+  });
+});
+
 describe('without hmr', () => {
   beforeEach(() => {
     mockCosmosConfig = {

--- a/packages/react-cosmos-webpack/src/webpack-config.js
+++ b/packages/react-cosmos-webpack/src/webpack-config.js
@@ -1,4 +1,5 @@
 import webpack from 'webpack';
+import omit from 'lodash.omit';
 import getConfig from './config';
 import resolveUserPath from './utils/resolve-user-path';
 import importModule from 'react-cosmos-utils/lib/import-module';
@@ -44,7 +45,7 @@ export default function getWebpackConfig(
     publicPath: '/loader/',
   };
 
-  // use what user wants
+  // To support webpack 1 and 2 configuration formats. So we use the one that user passes
   const webpackRulesOptionName = userWebpackConfig.module && userWebpackConfig.module.rules ? 'rules' : 'loaders';
   const rules = userWebpackConfig.module && userWebpackConfig.module[webpackRulesOptionName] ?
     [...userWebpackConfig.module[webpackRulesOptionName]] : [];
@@ -71,6 +72,7 @@ export default function getWebpackConfig(
     entry,
     output,
     module: {
+      ...omit(userWebpackConfig.module, 'rules', 'loaders'),
       [webpackRulesOptionName]: rules,
     },
     plugins,

--- a/packages/react-cosmos-webpack/src/webpack-config.js
+++ b/packages/react-cosmos-webpack/src/webpack-config.js
@@ -44,15 +44,13 @@ export default function getWebpackConfig(
     publicPath: '/loader/',
   };
 
-  if (userWebpackConfig.module && userWebpackConfig.module.rules) {
-    throw new Error('Please use `loaders` instead of `rules` in your webpack config');
-  }
-
-  const loaders = userWebpackConfig.module && userWebpackConfig.module.loaders ?
-    [...userWebpackConfig.module.loaders] : [];
+  // use what user wants
+  const webpackRulesOptionName = userWebpackConfig.module && userWebpackConfig.module.rules ? 'rules' : 'loaders';
+  const rules = userWebpackConfig.module && userWebpackConfig.module[webpackRulesOptionName] ?
+    [...userWebpackConfig.module[webpackRulesOptionName]] : [];
   const plugins = userWebpackConfig.plugins ? [...userWebpackConfig.plugins] : [];
 
-  loaders.push({
+  rules.push({
     loader: require.resolve('./module-loader'),
     include: require.resolve('./user-modules'),
     query: {
@@ -73,8 +71,7 @@ export default function getWebpackConfig(
     entry,
     output,
     module: {
-      ...userWebpackConfig.module,
-      loaders,
+      [webpackRulesOptionName]: rules,
     },
     plugins,
   };

--- a/packages/react-cosmos-webpack/src/webpack-config.js
+++ b/packages/react-cosmos-webpack/src/webpack-config.js
@@ -44,6 +44,10 @@ export default function getWebpackConfig(
     publicPath: '/loader/',
   };
 
+  if (userWebpackConfig.module && userWebpackConfig.module.rules) {
+    throw new Error('Please use `loaders` instead of `rules` in your webpack config');
+  }
+
   const loaders = userWebpackConfig.module && userWebpackConfig.module.loaders ?
     [...userWebpackConfig.module.loaders] : [];
   const plugins = userWebpackConfig.plugins ? [...userWebpackConfig.plugins] : [];


### PR DESCRIPTION
I spent an hour getting to know why my build wasn't working. It failed with an error
```
get-contexts.js:14 Uncaught ReferenceError: COMPONENT_CONTEXTS is not defined
```

So the problem was with webpack configuration - I had to use `module.loaders` in my webpack.config. I know that there is a note about it in readme. But i think it's not obvious. 
