### PR TITLE
Restrict context file types to js/jsx

### DIFF
--- a/packages/react-cosmos-webpack/src/__tests__/module-loader.js
+++ b/packages/react-cosmos-webpack/src/__tests__/module-loader.js
@@ -43,7 +43,7 @@ const loaderOutput = moduleLoader.call(loaderContext, loaderInput);
 
 // Replace actual request calls with a mock of their signature
 // eslint-disable-next-line no-unused-vars
-const __req = path => `__req(${path})`;
+const __req = (...args) => `__req(${[...args]})`;
 
 const [, componentsOutput, fixturesOutput, proxiesOutput, contextsOutput] =
   loaderOutput.match(/^components = (.+); fixtures = (.+); proxies = (.+); contexts = (.+);$/);
@@ -100,9 +100,9 @@ test('injects contexts', () => {
   const contexts = eval(`(${contextsOutput.replace(/require.context/g, '__req')})`);
 
   expect(contexts).toEqual([
-    '__req(components)',
-    '__req(components/__fixtures__/Foo)',
-    '__req(components/__fixtures__/Bar)',
+    '__req(components,false,/\\.jsx?$/)',
+    '__req(components/__fixtures__/Foo,false,/\\.jsx?$/)',
+    '__req(components/__fixtures__/Bar,false,/\\.jsx?$/)',
   ]);
 });
 

--- a/packages/react-cosmos-webpack/src/module-loader.js
+++ b/packages/react-cosmos-webpack/src/module-loader.js
@@ -47,7 +47,7 @@ const getUniqueDirsOfUserModules = (components, fixtures) => {
 };
 
 const convertDirPathsToContextCalls = dirPaths =>
-  `[${dirPaths.map(dirPath => `require.context('${dirPath}', false)`)}]`;
+  `[${dirPaths.map(dirPath => `require.context('${dirPath}', false), /\\.jsx?$/`)}]`;
 
 /**
  * Inject require calls in bundle for each component/fixture path and

--- a/packages/react-cosmos-webpack/src/module-loader.js
+++ b/packages/react-cosmos-webpack/src/module-loader.js
@@ -47,7 +47,7 @@ const getUniqueDirsOfUserModules = (components, fixtures) => {
 };
 
 const convertDirPathsToContextCalls = dirPaths =>
-  `[${dirPaths.map(dirPath => `require.context('${dirPath}', false), /\\.jsx?$/`)}]`;
+  `[${dirPaths.map(dirPath => `require.context('${dirPath}', false, /\\.jsx?$/)`)}]`;
 
 /**
  * Inject require calls in bundle for each component/fixture path and


### PR DESCRIPTION
Parsing additional files is needless and will result in parse errors.