### PR TITLE
Enable updates to lockfile through Greenkeeper

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,18 @@
 language: node_js
 node_js:
   - "5"
+before_install:
+  - yarn global add greenkeeper-lockfile@1
+before_script:
+  - greenkeeper-lockfile-update
 script:
-  - npm run test
-  - npm run test-smoke-ci
+  - yarn run test
+  - yarn run test-smoke-ci
+after_script:
+  - greenkeeper-lockfile-upload
 after_success:
-  - npm run coveralls
+  - yarn run coveralls
 cache:
+  yarn: true
   directories:
     - /home/travis/.cypress/Cypress

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: node_js
 node_js:
-  - "5"
+  - "6"
 before_install:
   - yarn global add greenkeeper-lockfile@1
 before_script:


### PR DESCRIPTION
Greenkeeper has added support for updating the yarn lockfile when it bumps a dependency through [greenkeeper-lockfile](https://github.com/greenkeeperio/greenkeeper-lockfile).

Already tested this [here](https://github.com/react-bucharest/mugshot-demo/pull/8) and it seems to work [fine](https://github.com/react-bucharest/mugshot-demo/pull/12) though existing PRs with version bumps might not get a lockfile update. Also, I added my own access token `GH_TOKEN` in Travis.

