### PR TITLE
Disable updates to lockfile through Greenkeeper

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,15 +1,9 @@
 language: node_js
 node_js:
   - "6"
-before_install:
-  - yarn global add greenkeeper-lockfile@1
-before_script:
-  - greenkeeper-lockfile-update
 script:
   - yarn run test
   - yarn run test-smoke-ci
-after_script:
-  - greenkeeper-lockfile-upload
 after_success:
   - yarn run coveralls
 cache:


### PR DESCRIPTION
Lockfile updates are failing in Travis due to [a bug](https://github.com/greenkeeperio/greenkeeper-lockfile/issues/40) in `greenkeeper-lockfile` with no resolution in sight. Let's drop this functionality for now.
