### PR TITLE
Disable Cypress record

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "test": "yarn run lint && yarn run test-jest",
     "coveralls": "cat coverage/lcov.info | node_modules/coveralls/bin/coveralls.js",
     "test-smoke": "cypress run",
-    "test-smoke-ci": "yarn start & cypress run --record"
+    "test-smoke-ci": "yarn start & cypress run"
   },
   "dependencies": {
     "babel-cli": "^6.16.0",


### PR DESCRIPTION
It doesn't work for most PRs because Travis env vars–where the `CYPRESS_RECORD_KEY` is stored–are not available in fork PRs. Failing all builds that are not from org members is annoying.