### PR TITLE
[WIP] Create blank fixtures for components

### DIFF
--- a/examples/local-state/package.json
+++ b/examples/local-state/package.json
@@ -4,7 +4,8 @@
   "repository": "https://github.com/react-cosmos/react-cosmos/tree/master/examples/local-state",
   "license": "MIT",
   "scripts": {
-    "start": "node ../../packages/react-cosmos-webpack/bin/cosmos.js"
+    "start": "node ../../packages/react-cosmos-webpack/bin/cosmos.js",
+    "create-fixtures": "node ../../packages/react-cosmos-webpack/bin/cosmos-create-fixtures.js"
   },
   "xo": false
 }

--- a/packages/react-cosmos-voyager/package.json
+++ b/packages/react-cosmos-voyager/package.json
@@ -19,7 +19,8 @@
     "touch": "^1.0.0"
   },
   "dependencies": {
-    "glob": "^7.1.1"
+    "glob": "^7.1.1",
+    "react-cosmos-config": "^2.0.0-beta.15"
   },
   "xo": false
 }

--- a/packages/react-cosmos-voyager/package.json
+++ b/packages/react-cosmos-voyager/package.json
@@ -19,7 +19,9 @@
     "touch": "^1.0.0"
   },
   "dependencies": {
+    "fs-extra": "^3.0.1",
     "glob": "^7.1.1",
+    "lodash.find": "^4.6.0",
     "react-cosmos-config": "^2.0.0-beta.15"
   },
   "xo": false

--- a/packages/react-cosmos-voyager/package.json
+++ b/packages/react-cosmos-voyager/package.json
@@ -21,7 +21,6 @@
   "dependencies": {
     "fs-extra": "^3.0.1",
     "glob": "^7.1.1",
-    "lodash.find": "^4.6.0",
     "react-cosmos-config": "^2.0.0-beta.15"
   },
   "xo": false

--- a/packages/react-cosmos-voyager/src/create-fixtures.js
+++ b/packages/react-cosmos-voyager/src/create-fixtures.js
@@ -57,12 +57,13 @@ function createBlankFixturesForComponents(componentPaths, cosmosConfig) {
 }
 
 function getFixturesFolder(path, componentPaths) {
-  if (basename(path).match(new RegExp(`${basename(basename(dirname(path)))}.(js|jsx)$`))) {
+  if (basename(path).match(new RegExp(`${basename(dirname(path))}.(js|jsx)$`))) {
     //also works if you have one folder per component
     return `${dirname(path)}/__fixtures__`;
   }
-  //By default, it looks for a __fixtures__ dir next to your components.
-  //TODO: improve this approach to finding root of components folder
+  // By default, it looks for a __fixtures__ dir next to your components.
+  // TODO: Improve this approach to finding root of components folder
+  // TODO: Handle cosmos config componentPaths as globs and file paths
   const componentsFolder = find(componentPaths, p => path.indexOf(p) > -1);
   const relativeComponentFolder = path.replace(componentsFolder, '');
   return `${componentsFolder}/__fixtures__${relativeComponentFolder.substr(

--- a/packages/react-cosmos-voyager/src/create-fixtures.js
+++ b/packages/react-cosmos-voyager/src/create-fixtures.js
@@ -1,16 +1,17 @@
 import { argv } from 'yargs';
-import { dirname } from 'path';
-import { existsSync, mkdirSync, writeFileSync } from 'fs';
+import { dirname, basename } from 'path';
 import getCosmosConfig from 'react-cosmos-config';
 import getFilePaths from './index';
 import reduce from 'lodash.reduce';
+import find from 'lodash.find';
+import fs from 'fs-extra';
 
 module.exports = function startCreateFixtures() {
-  createBlankFixturesForComponents(getComponentsWithoutFixtures());
+  const cosmosConfig = getCosmosConfig(argv.config);
+  createBlankFixturesForComponents(getComponentsWithoutFixtures(cosmosConfig), cosmosConfig);
 };
 
-function getComponentsWithoutFixtures() {
-  const cosmosConfig = getCosmosConfig(argv.config);
+function getComponentsWithoutFixtures(cosmosConfig) {
   const { components, fixtures } = getFilePaths(cosmosConfig);
   return reduce(
     components,
@@ -24,20 +25,19 @@ function getComponentsWithoutFixtures() {
   );
 }
 
-function createBlankFixturesForComponents(componentPaths) {
+function createBlankFixturesForComponents(componentPaths, cosmosConfig) {
   const result = reduce(
     componentPaths,
     (final, path, componentName) => {
-      const fixturesFolder = `${dirname(path)}/__fixtures__`;
-      const fixture = `${fixturesFolder}/default.js`;
+      const fixturesFolder = getFixturesFolder(path, cosmosConfig.componentPaths);
+      const fixture = `${fixturesFolder}/empty.js`;
       try {
-        ensureFixturesFolderExists(fixturesFolder);
-        writeFileSync(
+        fs.ensureDirSync(fixturesFolder);
+        fs.outputFileSync(
           fixture,
           `// Blank fixture created by cosmos-create-fixtures
     export default {};
-    `,
-          'utf8'
+    `
         );
         final.success.push({ componentName, fixture });
       } catch (err) {
@@ -56,9 +56,17 @@ function createBlankFixturesForComponents(componentPaths) {
   );
 }
 
-function ensureFixturesFolderExists(dirname) {
-  if (existsSync(dirname)) {
-    return;
+function getFixturesFolder(path, componentPaths) {
+  if (basename(path).match(new RegExp(`${basename(basename(dirname(path)))}.(js|jsx)$`))) {
+    //also works if you have one folder per component
+    return `${dirname(path)}/__fixtures__`;
   }
-  mkdirSync(dirname);
+  //By default, it looks for a __fixtures__ dir next to your components.
+  //TODO: improve this approach to finding root of components folder
+  const componentsFolder = find(componentPaths, p => path.indexOf(p) > -1);
+  const relativeComponentFolder = path.replace(componentsFolder, '');
+  return `${componentsFolder}/__fixtures__${relativeComponentFolder.substr(
+    0,
+    relativeComponentFolder.lastIndexOf('.')
+  ) || relativeComponentFolder}`;
 }

--- a/packages/react-cosmos-voyager/src/create-fixtures.js
+++ b/packages/react-cosmos-voyager/src/create-fixtures.js
@@ -60,7 +60,7 @@ export function getFixturesFolderForComponent(componentPath, filePath, fixturesD
     return `${dirname(filePath)}/${fixturesDir}`;
   }
   // Create fixture in root level fixturesDir with matching dir structure as component's filePath
-  return `${componentPath}/${fixturesDir}${getComponentFolderRelativeToComponentPath(componentPath, filePath)}`
+  return `${componentPath}/${fixturesDir}${getDirStructureforComponent(componentPath, filePath)}`
 }
 
 /**
@@ -72,7 +72,7 @@ export function getFixturesFolderForComponent(componentPath, filePath, fixturesD
  * @param  {string} filePath      component file path
  * @return {string}               Dir path of component relative to componentPath
  */
-function getComponentFolderRelativeToComponentPath(componentPath, filePath) {
+function getDirStructureforComponent(componentPath, filePath) {
   return removeFileExtension(filePath.replace(componentPath, ''))
 }
 

--- a/packages/react-cosmos-voyager/src/create-fixtures.js
+++ b/packages/react-cosmos-voyager/src/create-fixtures.js
@@ -2,13 +2,17 @@ import { argv } from 'yargs';
 import { dirname } from 'path';
 import { existsSync, mkdirSync, writeFileSync } from 'fs';
 import getCosmosConfig from 'react-cosmos-config';
-import getFilePaths from 'react-cosmos-voyager';
+import getFilePaths from './index';
 import reduce from 'lodash.reduce';
 
 module.exports = function startCreateFixtures() {
+  createBlankFixturesForComponents(getComponentsWithoutFixtures());
+};
+
+function getComponentsWithoutFixtures() {
   const cosmosConfig = getCosmosConfig(argv.config);
   const { components, fixtures } = getFilePaths(cosmosConfig);
-  const noFixtures = reduce(
+  return reduce(
     components,
     (final, componentPath, componentName) => {
       if (!fixtures[componentName] || Object.keys(fixtures[componentName]).length === 0) {
@@ -18,16 +22,11 @@ module.exports = function startCreateFixtures() {
     },
     {}
   );
-  if (Object.keys(noFixtures).length === 0) {
-    console.log('[Cosmos] No fixtures created. Every component has at least one fixture.');
-  } else {
-    createMissingFixtures(noFixtures);
-  }
-};
+}
 
-function createMissingFixtures(noFixtures) {
+function createBlankFixturesForComponents(componentPaths) {
   const result = reduce(
-    noFixtures,
+    componentPaths,
     (final, path, componentName) => {
       const fixturesFolder = `${dirname(path)}/__fixtures__`;
       const fixture = `${fixturesFolder}/default.js`;
@@ -35,9 +34,9 @@ function createMissingFixtures(noFixtures) {
         ensureFixturesFolderExists(fixturesFolder);
         writeFileSync(
           fixture,
-          `// Empty fixture created by cosmos-create-fixtures
-export default {};
-`,
+          `// Blank fixture created by cosmos-create-fixtures
+    export default {};
+    `,
           'utf8'
         );
         final.success.push({ componentName, fixture });
@@ -52,8 +51,8 @@ export default {};
     }
   );
   console.log(
-    `[Cosmos] Create Fixtures Result: ${result.success.length}/${Object.keys(noFixtures)
-      .length} Created`
+    `[Cosmos] Create Fixtures Result: ${result.success.length}/${Object.keys(componentPaths)
+      .length} Blank Fixtures Created`
   );
 }
 

--- a/packages/react-cosmos-voyager/src/index.js
+++ b/packages/react-cosmos-voyager/src/index.js
@@ -98,7 +98,7 @@ const getFilePaths = ({
           [...relFixtures, ...extFixtures], componentName, fixturesDir
         );
         if (Object.keys(fixtures[componentName]).length === 0) {
-          missingFixtures[componentName] = getFixturesFolderForComponent(componentPath, filePath, fixturesDir);®
+          missingFixtures[componentName] = getFixturesFolderForComponent(componentPath, filePath, fixturesDir);
         }
       });
     }

--- a/packages/react-cosmos-voyager/yarn.lock
+++ b/packages/react-cosmos-voyager/yarn.lock
@@ -65,10 +65,6 @@ jsonfile@^3.0.0:
   optionalDependencies:
     graceful-fs "^4.1.6"
 
-lodash.find@^4.6.0:
-  version "4.6.0"
-  resolved "https://registry.yarnpkg.com/lodash.find/-/lodash.find-4.6.0.tgz#cb0704d47ab71789ffa0de8b97dd926fb88b13b1"
-
 lodash.isplainobject@^4.0.6:
   version "4.0.6"
   resolved "https://registry.yarnpkg.com/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz#7c526a52d89b45c45cc690b88163be0497f550cb"

--- a/packages/react-cosmos-voyager/yarn.lock
+++ b/packages/react-cosmos-voyager/yarn.lock
@@ -21,6 +21,14 @@ concat-map@0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/concat-map/-/concat-map-0.0.1.tgz#d8a96bd77fd68df7793a73036a3ba0d5405d477b"
 
+fs-extra@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-3.0.1.tgz#3794f378c58b342ea7dbbb23095109c4b3b62291"
+  dependencies:
+    graceful-fs "^4.1.2"
+    jsonfile "^3.0.0"
+    universalify "^0.1.0"
+
 fs.realpath@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/fs.realpath/-/fs.realpath-1.0.0.tgz#1504ad2523158caa40db4a2787cb01411994ea4f"
@@ -36,6 +44,10 @@ glob@^7.0.5, glob@^7.1.1:
     once "^1.3.0"
     path-is-absolute "^1.0.0"
 
+graceful-fs@^4.1.2, graceful-fs@^4.1.6:
+  version "4.1.11"
+  resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.1.11.tgz#0e8bdfe4d1ddb8854d64e04ea7c00e2a026e5658"
+
 inflight@^1.0.4:
   version "1.0.6"
   resolved "https://registry.yarnpkg.com/inflight/-/inflight-1.0.6.tgz#49bd6331d7d02d0c09bc910a1075ba8165b56df9"
@@ -46,6 +58,20 @@ inflight@^1.0.4:
 inherits@2:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.3.tgz#633c2c83e3da42a502f52466022480f4208261de"
+
+jsonfile@^3.0.0:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/jsonfile/-/jsonfile-3.0.1.tgz#a5ecc6f65f53f662c4415c7675a0331d0992ec66"
+  optionalDependencies:
+    graceful-fs "^4.1.6"
+
+lodash.find@^4.6.0:
+  version "4.6.0"
+  resolved "https://registry.yarnpkg.com/lodash.find/-/lodash.find-4.6.0.tgz#cb0704d47ab71789ffa0de8b97dd926fb88b13b1"
+
+lodash.isplainobject@^4.0.6:
+  version "4.0.6"
+  resolved "https://registry.yarnpkg.com/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz#7c526a52d89b45c45cc690b88163be0497f550cb"
 
 minimatch@^3.0.4:
   version "3.0.4"
@@ -79,6 +105,24 @@ path-is-absolute@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/path-is-absolute/-/path-is-absolute-1.0.1.tgz#174b9268735534ffbc7ace6bf53a5a9e1b5c5f5f"
 
+react-cosmos-config@^2.0.0-beta.15:
+  version "2.0.0-beta.15"
+  resolved "https://registry.yarnpkg.com/react-cosmos-config/-/react-cosmos-config-2.0.0-beta.15.tgz#58b5cc140c0742e517d63bd088a6a5f36fb1343a"
+  dependencies:
+    react-cosmos-utils "^2.0.0-beta.15"
+    resolve-from "^3.0.0"
+    slash "^1.0.0"
+
+react-cosmos-utils@^2.0.0-beta.15:
+  version "2.0.0-beta.15"
+  resolved "https://registry.yarnpkg.com/react-cosmos-utils/-/react-cosmos-utils-2.0.0-beta.15.tgz#00e33a1ffe893d80307c381bde489f0460c0c92f"
+  dependencies:
+    lodash.isplainobject "^4.0.6"
+
+resolve-from@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/resolve-from/-/resolve-from-3.0.0.tgz#b22c7af7d9d6881bc8b6e653335eebcb0a188748"
+
 rimraf@^2.5.4:
   version "2.6.1"
   resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.6.1.tgz#c2338ec643df7a1b7fe5c54fa86f57428a55f33d"
@@ -94,6 +138,10 @@ touch@^1.0.0:
   resolved "https://registry.yarnpkg.com/touch/-/touch-1.0.0.tgz#449cbe2dbae5a8c8038e30d71fa0ff464947c4de"
   dependencies:
     nopt "~1.0.10"
+
+universalify@^0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/universalify/-/universalify-0.1.0.tgz#9eb1c4651debcc670cc94f1a75762332bb967778"
 
 wrappy@1:
   version "1.0.2"

--- a/packages/react-cosmos-webpack/bin/cosmos-create-fixtures.js
+++ b/packages/react-cosmos-webpack/bin/cosmos-create-fixtures.js
@@ -1,0 +1,12 @@
+#!/usr/bin/env node
+
+const argv = require('yargs').argv;
+
+// Babel is included by default, but --plain will run only on Node features
+if (!argv.plain) {
+  require('babel-register');
+}
+
+const startCreateFixtures = require('../lib/create-fixtures');
+
+startCreateFixtures();

--- a/packages/react-cosmos-webpack/bin/cosmos-create-fixtures.js
+++ b/packages/react-cosmos-webpack/bin/cosmos-create-fixtures.js
@@ -7,6 +7,6 @@ if (!argv.plain) {
   require('babel-register');
 }
 
-const startCreateFixtures = require('../lib/create-fixtures');
+const startCreateFixtures = require('react-cosmos-voyager/lib/create-fixtures');
 
 startCreateFixtures();

--- a/packages/react-cosmos-webpack/src/create-fixtures.js
+++ b/packages/react-cosmos-webpack/src/create-fixtures.js
@@ -1,0 +1,65 @@
+import { argv } from 'yargs';
+import { dirname } from 'path';
+import { existsSync, mkdirSync, writeFileSync } from 'fs';
+import getCosmosConfig from 'react-cosmos-config';
+import getFilePaths from 'react-cosmos-voyager';
+import reduce from 'lodash.reduce';
+
+module.exports = function startCreateFixtures() {
+  const cosmosConfig = getCosmosConfig(argv.config);
+  const { components, fixtures } = getFilePaths(cosmosConfig);
+  const noFixtures = reduce(
+    components,
+    (final, componentPath, componentName) => {
+      if (!fixtures[componentName] || Object.keys(fixtures[componentName]).length === 0) {
+        final[componentName] = componentPath;
+      }
+      return final;
+    },
+    {}
+  );
+  if (Object.keys(noFixtures).length === 0) {
+    console.log('[Cosmos] No fixtures created. Every component has at least one fixture.');
+  } else {
+    createMissingFixtures(noFixtures);
+  }
+};
+
+function createMissingFixtures(noFixtures) {
+  const result = reduce(
+    noFixtures,
+    (final, path, componentName) => {
+      const fixturesFolder = `${dirname(path)}/__fixtures__`;
+      const fixture = `${fixturesFolder}/default.js`;
+      try {
+        ensureFixturesFolderExists(fixturesFolder);
+        writeFileSync(
+          fixture,
+          `// Empty fixture created by cosmos-create-fixtures
+export default {};
+`,
+          'utf8'
+        );
+        final.success.push({ componentName, fixture });
+      } catch (err) {
+        final.failure.push({ componentName, fixture });
+      }
+      return final;
+    },
+    {
+      success: [],
+      failure: []
+    }
+  );
+  console.log(
+    `[Cosmos] Create Fixtures Result: ${result.success.length}/${Object.keys(noFixtures)
+      .length} Created`
+  );
+}
+
+function ensureFixturesFolderExists(dirname) {
+  if (existsSync(dirname)) {
+    return;
+  }
+  mkdirSync(dirname);
+}


### PR DESCRIPTION
With https://github.com/react-cosmos/react-cosmos/pull/364 (merged), blank fixtures are no longer provided automatically.

**Requirements are still a WIP, but so far, this PR:**
Passes the result of `getComponentsWithoutFixtures` to `createBlankFixturesForComponents`, which creates an `empty.js` fixture file for each component without a fixture.

@skidding has described the end goal as
> In a pretty future, when the user visits the playground, he or she is greeted with "There are 3 new components since you last visited, would you like to create blank fixtures for them?". Then, the user checks some components from the list and submits.

Here's a mockup for review:
![screen shot 2017-07-10 at 9 04 35 am](https://user-images.githubusercontent.com/6405557/28019440-f1f4ac34-654e-11e7-8984-d42b1999586e.png)

