### PR TITLE
Support custom URL for static assets

### DIFF
--- a/README.md
+++ b/README.md
@@ -280,7 +280,8 @@ It's preferred to use CRA's own webpack config (instead of duplicating it).
 module.exports = {
   componentPaths: ['src/components'],
   containerQuerySelector: '#root',
-  webpackConfigPath: 'react-scripts/config/webpack.config.dev'
+  webpackConfigPath: 'react-scripts/config/webpack.config.dev',
+  publicPath: 'public'
 };
 ```
 
@@ -298,6 +299,8 @@ Next.js apps run on both client & server, so compilation is done via Babel plugi
 // cosmos.config.js
 module.exports = {
   componentPaths: ['components'],
+  publicPath: 'static',
+  publicUrl: '/static/',
 };
 ```
 
@@ -422,6 +425,9 @@ module.exports = {
   // Where to serve static files from. Like --content-base in webpack-dev-server.
   publicPath: 'src/public',
 
+  // Set base URL for static assets from public folder
+  publicUrl: '/static/',
+
   // Read more about proxies below
   proxies: [
     './redux-proxy.js',
@@ -432,8 +438,8 @@ module.exports = {
   // has styles attached, but bad for encapsulation.
   containerQuerySelector: '#app',
 
-  // Enable hot module replacement.
-  hot: true,
+  // Disable hot module replacement
+  hot: false,
 
   // These ones are self explanatory
   hostname: 'localhost',

--- a/packages/react-cosmos-component-playground/src/components/ComponentPlayground/__tests__/fixture-editor/controls.jsx
+++ b/packages/react-cosmos-component-playground/src/components/ComponentPlayground/__tests__/fixture-editor/controls.jsx
@@ -11,7 +11,7 @@ let wrapper;
 
 describe('Fixture editor controls', () => {
   // Fixture editor is already on so the button will untoggle it
-  const fixtureEditorUrl = '/?component=ComponentA&fixture=foo';
+  const fixtureEditorUrl = '?component=ComponentA&fixture=foo';
 
   beforeEach(() => {
     return new Promise(resolve => {

--- a/packages/react-cosmos-component-playground/src/components/ComponentPlayground/__tests__/fixture-selected.jsx
+++ b/packages/react-cosmos-component-playground/src/components/ComponentPlayground/__tests__/fixture-selected.jsx
@@ -114,15 +114,15 @@ describe('CP with fixture already selected', () => {
   });
 
   describe('main menu', () => {
-    const fixtureEditorUrl = '/?component=ComponentA&fixture=foo&editor=true';
-    const fullScreenUrl = '/?component=ComponentA&fixture=foo&fullScreen=true';
+    const fixtureEditorUrl = '?component=ComponentA&fixture=foo&editor=true';
+    const fullScreenUrl = '?component=ComponentA&fixture=foo&fullScreen=true';
 
     it('should render home button', () => {
-      expect(wrapper.find('a[href="/"].button')).toHaveLength(1);
+      expect(wrapper.find('a[href="?"].button')).toHaveLength(1);
     });
 
     it('should not render selected home button', () => {
-      expect(wrapper.find('a[href="/"].selectedButton')).toHaveLength(0);
+      expect(wrapper.find('a[href="?"].selectedButton')).toHaveLength(0);
     });
 
     it('should render fixture editor button', () => {

--- a/packages/react-cosmos-component-playground/src/components/ComponentPlayground/__tests__/fixtures-loaded.jsx
+++ b/packages/react-cosmos-component-playground/src/components/ComponentPlayground/__tests__/fixtures-loaded.jsx
@@ -68,11 +68,11 @@ describe('CP fixtures loaded', () => {
 
   describe('main menu', () => {
     test('should render home button', () => {
-      expect(wrapper.find('a[href="/"].button')).toHaveLength(1);
+      expect(wrapper.find('a[href="?"].button')).toHaveLength(1);
     });
 
     test('should render selected home button', () => {
-      expect(wrapper.find('a[href="/"].selectedButton')).toHaveLength(1);
+      expect(wrapper.find('a[href="?"].selectedButton')).toHaveLength(1);
     });
   });
 

--- a/packages/react-cosmos-component-playground/src/components/ComponentPlayground/index.jsx
+++ b/packages/react-cosmos-component-playground/src/components/ComponentPlayground/index.jsx
@@ -308,7 +308,7 @@ export default class ComponentPlayground extends Component {
               <a
                 ref="homeButton"
                 className={homeClassNames}
-                href="/"
+                href="?"
                 onClick={router.routeLink}
               >
                 <HomeIcon />
@@ -319,7 +319,7 @@ export default class ComponentPlayground extends Component {
                 <a
                   ref="fixtureEditorButton"
                   className={fixtureEditorClassNames}
-                  href={`/${fixtureEditorUrl}`}
+                  href={`${fixtureEditorUrl}`}
                   onClick={router.routeLink}
                 >
                   <CodeIcon />
@@ -328,7 +328,7 @@ export default class ComponentPlayground extends Component {
                 <a
                   ref="fullScreenButton"
                   className={styles.button}
-                  href={`/${fullScreenUrl}`}
+                  href={`${fullScreenUrl}`}
                   onClick={router.routeLink}
                 >
                   <FullScreenIcon />

--- a/packages/react-cosmos-component-playground/src/components/ComponentPlayground/index.jsx
+++ b/packages/react-cosmos-component-playground/src/components/ComponentPlayground/index.jsx
@@ -319,7 +319,7 @@ export default class ComponentPlayground extends Component {
                 <a
                   ref="fixtureEditorButton"
                   className={fixtureEditorClassNames}
-                  href={`${fixtureEditorUrl}`}
+                  href={fixtureEditorUrl}
                   onClick={router.routeLink}
                 >
                   <CodeIcon />
@@ -328,7 +328,7 @@ export default class ComponentPlayground extends Component {
                 <a
                   ref="fullScreenButton"
                   className={styles.button}
-                  href={`${fullScreenUrl}`}
+                  href={fullScreenUrl}
                   onClick={router.routeLink}
                 >
                   <FullScreenIcon />

--- a/packages/react-cosmos-component-playground/src/components/ComponentPlayground/index.less
+++ b/packages/react-cosmos-component-playground/src/components/ComponentPlayground/index.less
@@ -36,7 +36,6 @@
   flex: 1;
   display: flex;
   flex-direction: column;
-  overflow: hidden;
 }
 
 .header {

--- a/packages/react-cosmos-component-playground/src/components/ComponentPlayground/index.less
+++ b/packages/react-cosmos-component-playground/src/components/ComponentPlayground/index.less
@@ -36,6 +36,7 @@
   flex: 1;
   display: flex;
   flex-direction: column;
+  overflow-x: hidden;
 }
 
 .header {

--- a/packages/react-cosmos-component-playground/src/components/ComponentPlayground/index.less
+++ b/packages/react-cosmos-component-playground/src/components/ComponentPlayground/index.less
@@ -141,6 +141,7 @@
   background-position: 0 0, @checkerboard-square-size @checkerboard-square-size;
 
   iframe {
+    position: absolute;
     width: 100%;
     height: 100%;
     border: 0;

--- a/packages/react-cosmos-component-playground/src/components/DragHandle/index.less
+++ b/packages/react-cosmos-component-playground/src/components/DragHandle/index.less
@@ -9,12 +9,12 @@
 
 .horizontal {
   width: @drag-handle-size;
-  height: 100%;
-  cursor: ew-resize;
+  height: auto;
+  cursor: col-resize;
 }
 
 .vertical {
-  width: 100%;
+  width: auto;
   height: @drag-handle-size;
-  cursor: ns-resize;
+  cursor: row-resize;
 }

--- a/packages/react-cosmos-component-playground/src/components/FixtureList/__tests__/index.jsx
+++ b/packages/react-cosmos-component-playground/src/components/FixtureList/__tests__/index.jsx
@@ -56,25 +56,25 @@ describe('Links', () => {
 
     test('link 1', () => {
       expect(componentA.find('.fixture').at(0).prop('href')).toEqual(
-        '/?component=ComponentA&fixture=foo'
+        '?component=ComponentA&fixture=foo'
       );
     });
 
     test('link 2', () => {
       expect(componentA.find('.fixture').at(1).prop('href')).toEqual(
-        '/?component=ComponentA&fixture=bar'
+        '?component=ComponentA&fixture=bar'
       );
     });
 
     test('link 3', () => {
       expect(componentB.find('.fixture').at(0).prop('href')).toEqual(
-        '/?component=ComponentB&fixture=baz'
+        '?component=ComponentB&fixture=baz'
       );
     });
 
     test('link 4', () => {
       expect(componentB.find('.fixture').at(1).prop('href')).toEqual(
-        '/?component=ComponentB&fixture=qux'
+        '?component=ComponentB&fixture=qux'
       );
     });
   });
@@ -90,25 +90,25 @@ describe('Links', () => {
 
     test('link 1', () => {
       expect(componentA.find('.fixture').at(0).prop('href')).toEqual(
-        '/?editor=true&component=ComponentA&fixture=foo'
+        '?editor=true&component=ComponentA&fixture=foo'
       );
     });
 
     test('link 2', () => {
       expect(componentA.find('.fixture').at(1).prop('href')).toEqual(
-        '/?editor=true&component=ComponentA&fixture=bar'
+        '?editor=true&component=ComponentA&fixture=bar'
       );
     });
 
     test('link 3', () => {
       expect(componentB.find('.fixture').at(0).prop('href')).toEqual(
-        '/?editor=true&component=ComponentB&fixture=baz'
+        '?editor=true&component=ComponentB&fixture=baz'
       );
     });
 
     test('link 4', () => {
       expect(componentB.find('.fixture').at(1).prop('href')).toEqual(
-        '/?editor=true&component=ComponentB&fixture=qux'
+        '?editor=true&component=ComponentB&fixture=qux'
       );
     });
   });

--- a/packages/react-cosmos-component-playground/src/components/FixtureList/index.jsx
+++ b/packages/react-cosmos-component-playground/src/components/FixtureList/index.jsx
@@ -122,7 +122,7 @@ export default class FixtureList extends Component {
                       <a
                         key={j}
                         className={fixtureClassNames}
-                        href={`${uri.stringifyParams(nextUrlParams)}`}
+                        href={uri.stringifyParams(nextUrlParams)}
                         onClick={this.onFixtureClick}
                       >
                         {fixture}

--- a/packages/react-cosmos-component-playground/src/components/FixtureList/index.jsx
+++ b/packages/react-cosmos-component-playground/src/components/FixtureList/index.jsx
@@ -101,14 +101,16 @@ export default class FixtureList extends Component {
               <div key={i} className={styles.component}>
                 <div className={styles.componentName}>
                   <FolderIcon />
-                  <span>{component}</span>
+                  <span>
+                    {component}
+                  </span>
                 </div>
                 <div>
                   {filteredFixtures[component].map((fixture, j) => {
                     const fixtureClassNames = classNames(styles.fixture, {
                       [styles.fixtureSelected]:
                         component === urlParams.component &&
-                          fixture === urlParams.fixture,
+                        fixture === urlParams.fixture,
                     });
                     const nextUrlParams = {
                       ...urlParams,
@@ -120,7 +122,7 @@ export default class FixtureList extends Component {
                       <a
                         key={j}
                         className={fixtureClassNames}
-                        href={`/${uri.stringifyParams(nextUrlParams)}`}
+                        href={`${uri.stringifyParams(nextUrlParams)}`}
                         onClick={this.onFixtureClick}
                       >
                         {fixture}

--- a/packages/react-cosmos-component-playground/src/components/FixtureList/index.less
+++ b/packages/react-cosmos-component-playground/src/components/FixtureList/index.less
@@ -9,6 +9,7 @@
   flex: 1;
   font-family: @default-font-family;
   -webkit-font-smoothing: antialiased;
+  overflow-y: hidden;
 }
 
 .searchInputContainer {
@@ -39,7 +40,8 @@
   font-size: @editor-font-size;
   transition: background-color .3s ease;
 
-  &:focus, &:active {
+  &:focus,
+  &:active {
     outline: none;
     background-color: @left-nav-bgcolor-selected;
   }

--- a/packages/react-cosmos-config/src/index.js
+++ b/packages/react-cosmos-config/src/index.js
@@ -4,9 +4,11 @@ import resolveFrom from 'resolve-from';
 import importModule from 'react-cosmos-utils/lib/import-module';
 
 const resolveUserPath = (userPath, rootPath) =>
-  slash(path.isAbsolute(userPath) ? userPath : (
-    resolveFrom.silent(rootPath, userPath) || path.join(rootPath, userPath)
-  ));
+  slash(
+    path.isAbsolute(userPath)
+      ? userPath
+      : resolveFrom.silent(rootPath, userPath) || path.join(rootPath, userPath)
+  );
 
 const defaults = {
   componentPaths: [],
@@ -20,6 +22,7 @@ const defaults = {
   proxies: [],
   webpackConfigPath: 'webpack.config',
   outputPath: 'cosmos-export',
+  publicUrl: '/loader/',
 };
 
 const PATHS = ['componentPaths', 'fixturePaths', 'globalImports', 'proxies'];

--- a/packages/react-cosmos-webpack/src/__tests__/server.js
+++ b/packages/react-cosmos-webpack/src/__tests__/server.js
@@ -267,15 +267,19 @@ describe('with custom cosmos config path', () => {
 
 describe('with public path', () => {
   beforeEach(() => {
-    startServer(
-      {},
-      {
-        publicPath: 'server/public',
-      }
-    );
+    const argv = {};
+    const config = {
+      publicPath: 'server/public',
+      publicUrl: '/static/',
+    };
+    startServer(argv, config);
   });
 
   commonTests();
+
+  test('adds public url to express server', () => {
+    expect(mockExpressInstance.use.mock.calls[1][0]).toBe('/static/');
+  });
 
   test('creates static server with public path', () => {
     expect(express.static.mock.calls[0][0]).toBe('server/public');

--- a/packages/react-cosmos-webpack/src/export.js
+++ b/packages/react-cosmos-webpack/src/export.js
@@ -55,7 +55,7 @@ module.exports = function startExport() {
   const cosmosConfigPath = argv.config;
   const cosmosConfig = getCosmosConfig(cosmosConfigPath);
 
-  const { webpackConfigPath, outputPath } = cosmosConfig;
+  const { webpackConfigPath, outputPath, publicPath, publicUrl } = cosmosConfig;
 
   let userWebpackConfig;
   if (moduleExists(webpackConfigPath)) {
@@ -73,6 +73,13 @@ module.exports = function startExport() {
     cosmosConfigPath,
     true
   );
+
+  // Copy static files first, so that the built index.html overrides the its
+  // template file (in case the static asserts are served from the root path)
+  if (publicPath) {
+    const exportPublicPath = path.join(outputPath, publicUrl);
+    fs.copySync(publicPath, exportPublicPath);
+  }
 
   runWebpackCompiler(loaderWebpackConfig)
     .then(() => {

--- a/packages/react-cosmos-webpack/src/loader-entry.js
+++ b/packages/react-cosmos-webpack/src/loader-entry.js
@@ -4,8 +4,14 @@
 // anything which might import React
 // https://github.com/facebook/react-devtools/issues/76#issuecomment-128091900
 if (process.env.NODE_ENV === 'development') {
-  window.__REACT_DEVTOOLS_GLOBAL_HOOK__ =
-    window.parent.__REACT_DEVTOOLS_GLOBAL_HOOK__;
+  // Accessing the parent window can throw when loading a static export without
+  // a web server (i.e. via file:/// protocol)
+  try {
+    window.__REACT_DEVTOOLS_GLOBAL_HOOK__ =
+      window.parent.__REACT_DEVTOOLS_GLOBAL_HOOK__;
+  } catch (err) {
+    console.error(err);
+  }
 }
 
 const { mount, unmount } = require('react-cosmos-loader');

--- a/packages/react-cosmos-webpack/src/server.js
+++ b/packages/react-cosmos-webpack/src/server.js
@@ -29,7 +29,7 @@ module.exports = function startServer() {
   const cosmosConfigPath = argv.config;
   const cosmosConfig = getCosmosConfig(cosmosConfigPath);
 
-  const { hostname, hot, port, webpackConfigPath } = cosmosConfig;
+  const { hostname, hot, port, webpackConfigPath, publicUrl } = cosmosConfig;
 
   let userWebpackConfig;
   if (moduleExists(webpackConfigPath)) {
@@ -63,7 +63,7 @@ module.exports = function startServer() {
   const publicPath = getPublicPath(cosmosConfig, userWebpackConfig);
   if (publicPath) {
     console.log(`[Cosmos] Serving static files from ${publicPath}`);
-    app.use('/loader/', express.static(publicPath));
+    app.use(publicUrl, express.static(publicPath));
   }
 
   const playgroundHtml = fs.readFileSync(


### PR DESCRIPTION
Closes #297

Also on this branch:
- [x] Export static assets as well
- [x] Relative paths inside CP #397
- [x] Fix CP UI in Firefox
- [x] ~~Fix CP in Safari~~ It's not perfect (fixture editor sometimes overlaps with Loader frame), but it's outside of scope and *much* better than before