### PR TITLE
Fix create-react-app example cosmos.config.js

### DIFF
--- a/README.md
+++ b/README.md
@@ -305,7 +305,7 @@ It's preferred to use CRA's own webpack config (instead of duplicating it).
 ```js
 // cosmos.config.js
 module.exports = {
-  componentPaths: ['src/components'],
+  componentPaths: ['src'],
   containerQuerySelector: '#root',
   webpackConfigPath: 'react-scripts/config/webpack.config.dev',
   publicPath: 'public'

--- a/README.md
+++ b/README.md
@@ -305,11 +305,10 @@ It's preferred to use CRA's own webpack config (instead of duplicating it).
 ```js
 // cosmos.config.js
 module.exports = {
-  componentPaths: ['src'],
+  componentPaths: ['src/components'],
   containerQuerySelector: '#root',
   webpackConfigPath: 'react-scripts/config/webpack.config.dev',
-  publicPath: 'public',
-  ignore: [/App.test.js/]
+  publicPath: 'public'
 };
 ```
 

--- a/README.md
+++ b/README.md
@@ -315,6 +315,7 @@ module.exports = {
 
 Also make sure to:
 - Run `cosmos` with `NODE_ENV=development`
+- Create the `src/components` directory and place your components there, or change componentPaths option to match your existing structure.
 - Put [proxies](#proxies) in the `src` dir–the only place included by the CRA Babel loader
 
 *CRA + Cosmos example: [Flatris](https://github.com/skidding/flatris)*

--- a/README.md
+++ b/README.md
@@ -308,7 +308,8 @@ module.exports = {
   componentPaths: ['src'],
   containerQuerySelector: '#root',
   webpackConfigPath: 'react-scripts/config/webpack.config.dev',
-  publicPath: 'public'
+  publicPath: 'public',
+  ignore: [/App.test.js/]
 };
 ```
 


### PR DESCRIPTION
In the `create-react-app` section of the documentation, there is an example config that looks like this:

```
module.exports = {
   componentPaths: ['src/components'],
  // ... 
}
```
When I ran the above in a new `create-react-app` I found that webpack had a compilation error due to the fact that new `create-react-app`s do not have a `components` sub directory.  The fix for me was this:

```
module.exports = {
   componentPaths: ['src'],
  // ... 
}
```

The next issue was the console complaining that `it` was not defined, so also needed to add an ignore:

```
module.exports = {
   componentPaths: ['src'],
   ignore: [/App.test.js/]
  // ... 
}
```

Another thing I noticed is that the the above is going to show `registerServiceWorker` and `index` as component folders...a step further would be to update the config with an ignore like this:

```
module.exports = {
  componentPaths: ['src'],
  containerQuerySelector: '#root',
  webpackConfigPath: 'react-scripts/config/webpack.config.dev',
  publicPath: 'public',
  ignore: [/App.test.js/, /registerServiceWorker.js/, /index.js/]
};
```

The issue I have with the above is that without context it could be confusing for new users using `create-react-app` to test `cosmos` for the first time.