### PR TITLE
Preserve loader state after HMR update

### DIFF
--- a/cypress/integration/local-state_spec.js
+++ b/cypress/integration/local-state_spec.js
@@ -117,5 +117,15 @@ describe('Local state example', () => {
     it('should update fixture contents inside editor', () => {
       cy.get('.CodeMirror-line:eq(4)').should('contain', '"value": 4');
     });
+
+    it('should preseve state after HMR update', () => {
+      cy.get('iframe').then($iframe => {
+        $iframe[0].contentWindow.__startCosmosLoader();
+        cy
+          .wait(100) // Wait for postMessage communication to occur
+          .get('.CodeMirror-line:eq(4)')
+          .should('have.text', '        "value": 4');
+      });
+    });
   });
 });

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "child-process-promise": "^2.2.0",
     "coveralls": "^2.13.1",
     "css-loader": "^0.28.5",
-    "cypress-cli": "^0.13.1",
+    "cypress-cli": "^0.14.0",
     "enzyme": "^2.9.1",
     "eslint-config-xo-react": "^0.13.0",
     "eslint-import-resolver-webpack": "^0.8.3",
@@ -49,10 +49,10 @@
     "husky": "^0.14.3",
     "identity-obj-proxy": "^3.0.0",
     "jest": "^21.1.0",
-    "lerna": "^2.1.0",
+    "lerna": "^2.2.0",
     "less": "^2.7.1",
     "less-loader": "^4.0.5",
-    "lint-staged": "^4.0.4",
+    "lint-staged": "^4.2.1",
     "prettier": "^1.5.3",
     "prop-types": "^15.5.10",
     "react": "^15.6.1",
@@ -62,9 +62,9 @@
     "style-loader": "^0.18.2",
     "traverse": "^0.6.6",
     "url-loader": "^0.5.9",
-    "webpack": "^3.5.5",
+    "webpack": "^3.6.0",
     "xo": "^0.18.2",
-    "yargs": "^8.0.2"
+    "yargs": "^9.0.1"
   },
   "xo": {
     "space": true,

--- a/packages/react-cosmos-loader/package.json
+++ b/packages/react-cosmos-loader/package.json
@@ -9,6 +9,7 @@
   ],
   "main": "lib/index.js",
   "dependencies": {
+    "deep-equal": "^1.0.1",
     "lodash.merge": "^4.6.0",
     "prop-types": "^15.5.10",
     "react-cosmos-state-proxy": "^2.0.0-rc.1",

--- a/packages/react-cosmos-loader/src/components/RemoteLoader/__tests__/component-change.js
+++ b/packages/react-cosmos-loader/src/components/RemoteLoader/__tests__/component-change.js
@@ -67,10 +67,7 @@ describe('Component source changes', () => {
       })
       .then(() => onFixtureLoad)
       .then(() => {
-        const { onFixtureUpdate } = wrapper
-          .find(ProxyFoo)
-          .find(ProxyFoo)
-          .props();
+        const { onFixtureUpdate } = wrapper.find(ProxyFoo).props();
 
         // Simulate a state change to see if the HMR doesn't invalidate it
         onFixtureUpdate({

--- a/packages/react-cosmos-loader/src/components/RemoteLoader/__tests__/component-change.js
+++ b/packages/react-cosmos-loader/src/components/RemoteLoader/__tests__/component-change.js
@@ -67,9 +67,26 @@ describe('Component source changes', () => {
       })
       .then(() => onFixtureLoad)
       .then(() => {
+        const { onFixtureUpdate } = wrapper
+          .find(ProxyFoo)
+          .find(ProxyFoo)
+          .props();
+
+        // Simulate a state change to see if the HMR doesn't invalidate it
+        onFixtureUpdate({
+          foo: true
+        });
+
+        // Simulate a HMR update
         wrapper.setProps({
           components: {
             Foo: ComponentFoo2
+          },
+          // Re-create fixture structure with same references
+          fixtures: {
+            Foo: {
+              foo: fixtureFoo
+            }
           }
         });
 
@@ -79,5 +96,9 @@ describe('Component source changes', () => {
 
   test('sends new component to proxies', () => {
     expect(firstProxyWrapper.props().component).toBe(ComponentFoo2);
+  });
+
+  test('preserves previous fixture state', () => {
+    expect(firstProxyWrapper.props().fixture).toEqual({ foo: true });
   });
 });

--- a/packages/react-cosmos-loader/src/components/RemoteLoader/index.js
+++ b/packages/react-cosmos-loader/src/components/RemoteLoader/index.js
@@ -1,6 +1,7 @@
 import React, { Component } from 'react';
 import { object, objectOf, func, arrayOf } from 'prop-types';
 import merge from 'lodash.merge';
+import deepEqual from 'deep-equal';
 import splitUnserializableParts from 'react-cosmos-utils/lib/unserializable-parts';
 import createLinkedList from 'react-cosmos-utils/lib/linked-list';
 import createModuleType from '../../utils/module-type';
@@ -90,37 +91,40 @@ class RemoteLoader extends Component {
   }
 
   componentWillReceiveProps({ proxies, fixtures }) {
-    if (proxies !== this.props.proxies) {
+    if (!deepEqual(proxies, this.props.proxies)) {
       this.firstProxy = createProxyLinkedList(proxies);
     }
 
-    if (fixtures === this.props.fixtures) {
-      return;
+    // Keep parent frame in sync when fixture files are added to fs
+    const fixtureNames = extractFixtureNames(fixtures);
+    if (!deepEqual(fixtureNames, extractFixtureNames(this.props.fixtures))) {
+      postMessageToParent({
+        type: 'fixtureListUpdate',
+        fixtures: fixtureNames
+      });
     }
 
-    // Keep parent frame in sync when fixture files change (udpated via
-    // webpack HMR)
-    postMessageToParent({
-      type: 'fixtureListUpdate',
-      fixtures: extractFixtureNames(fixtures)
-    });
-
+    // Fixture file changes override updated fixture state
     const { component, fixture } = this.state;
-
-    // Reset fixture state to reflect fixture file changes
-    this.setState(
-      getFixtureState({
-        fixtures,
-        component,
-        fixture
-      }),
-      () => {
-        if (component && fixture) {
-          // Keep parent frame in sync with latest fixture body
-          this.onFixtureUpdate(this.state.fixtureBody.serializable);
+    const isFixtureSelected = component && fixture;
+    if (
+      isFixtureSelected &&
+      fixtures[component][fixture] !== this.props.fixtures[component][fixture]
+    ) {
+      this.setState(
+        getFixtureState({
+          fixtures,
+          component,
+          fixture
+        }),
+        () => {
+          if (isFixtureSelected) {
+            // Keep parent frame in sync with latest fixture body
+            this.onFixtureUpdate(this.state.fixtureBody.serializable);
+          }
         }
-      }
-    );
+      );
+    }
   }
 
   componentWillUnmount() {

--- a/packages/react-cosmos-loader/src/components/RemoteLoader/index.js
+++ b/packages/react-cosmos-loader/src/components/RemoteLoader/index.js
@@ -69,24 +69,24 @@ class RemoteLoader extends Component {
    * It both receives fixture changes from parent frame and sends fixture
    * updates bubbled up from proxy chain (due to state changes) to parent frame.
    */
-  state = noFixtureState;
-
   constructor(props) {
     super(props);
 
+    this.state = props.initialState || noFixtureState;
     this.firstProxy = createProxyLinkedList(props.proxies);
   }
 
   componentDidMount() {
     window.addEventListener('message', this.onMessage, false);
 
-    // Let parent know loader is ready to render, along with the initial
-    // fixture list (which might update later due to HMR)
-    const { fixtures } = this.props;
-    postMessageToParent({
-      type: 'loaderReady',
-      fixtures: extractFixtureNames(fixtures)
-    });
+    if (!this.props.initialState) {
+      // Let parent know loader is ready to render, along with the initial
+      // fixture list (which might update later due to HMR)
+      postMessageToParent({
+        type: 'loaderReady',
+        fixtures: extractFixtureNames(this.props.fixtures)
+      });
+    }
   }
 
   componentWillReceiveProps({ proxies, fixtures }) {
@@ -231,6 +231,7 @@ class RemoteLoader extends Component {
 }
 
 RemoteLoader.propTypes = {
+  initialState: object,
   components: objectOf(createModuleType(func)).isRequired,
   fixtures: objectOf(objectOf(createModuleType(object))).isRequired,
   proxies: arrayOf(createModuleType(func))

--- a/packages/react-cosmos-loader/src/components/RemoteLoader/index.js
+++ b/packages/react-cosmos-loader/src/components/RemoteLoader/index.js
@@ -70,10 +70,11 @@ class RemoteLoader extends Component {
    * It both receives fixture changes from parent frame and sends fixture
    * updates bubbled up from proxy chain (due to state changes) to parent frame.
    */
+  state = noFixtureState;
+
   constructor(props) {
     super(props);
 
-    this.state = noFixtureState;
     this.firstProxy = createProxyLinkedList(props.proxies);
   }
 

--- a/packages/react-cosmos-loader/src/components/RemoteLoader/index.js
+++ b/packages/react-cosmos-loader/src/components/RemoteLoader/index.js
@@ -73,21 +73,19 @@ class RemoteLoader extends Component {
   constructor(props) {
     super(props);
 
-    this.state = props.initialState || noFixtureState;
+    this.state = noFixtureState;
     this.firstProxy = createProxyLinkedList(props.proxies);
   }
 
   componentDidMount() {
     window.addEventListener('message', this.onMessage, false);
 
-    if (!this.props.initialState) {
-      // Let parent know loader is ready to render, along with the initial
-      // fixture list (which might update later due to HMR)
-      postMessageToParent({
-        type: 'loaderReady',
-        fixtures: extractFixtureNames(this.props.fixtures)
-      });
-    }
+    // Let parent know loader is ready to render, along with the initial
+    // fixture list (which might update later due to HMR)
+    postMessageToParent({
+      type: 'loaderReady',
+      fixtures: extractFixtureNames(this.props.fixtures)
+    });
   }
 
   componentWillReceiveProps({ proxies, fixtures }) {
@@ -235,7 +233,6 @@ class RemoteLoader extends Component {
 }
 
 RemoteLoader.propTypes = {
-  initialState: object,
   components: objectOf(createModuleType(func)).isRequired,
   fixtures: objectOf(objectOf(createModuleType(object))).isRequired,
   proxies: arrayOf(createModuleType(func))

--- a/packages/react-cosmos-loader/src/index.js
+++ b/packages/react-cosmos-loader/src/index.js
@@ -1,3 +1,3 @@
-export { mount, unmount } from './mount';
+export { mount } from './mount';
 export { default as Loader } from './components/Loader';
 export { default as RemoteLoader } from './components/RemoteLoader';

--- a/packages/react-cosmos-loader/src/mount.js
+++ b/packages/react-cosmos-loader/src/mount.js
@@ -3,6 +3,10 @@ import { render, unmountComponentAtNode } from 'react-dom';
 import RemoteLoader from './components/RemoteLoader';
 import createStateProxy from 'react-cosmos-state-proxy';
 
+// Reuse proxy instance between renders to be able to do deep equals between
+// RemoteLoader prop transitions and know whether the user proxies changed.
+const StateProxy = createStateProxy();
+
 let domContainer;
 let loaderRef;
 let prevState;
@@ -37,7 +41,7 @@ export function mount({
       proxies={[
         ...proxies,
         // Loaded by default in all configs
-        createStateProxy()
+        StateProxy
       ]}
     />,
     container

--- a/packages/react-cosmos-loader/src/mount.js
+++ b/packages/react-cosmos-loader/src/mount.js
@@ -1,15 +1,10 @@
 import React from 'react';
-import { render, unmountComponentAtNode } from 'react-dom';
+import { render } from 'react-dom';
 import RemoteLoader from './components/RemoteLoader';
 import createStateProxy from 'react-cosmos-state-proxy';
 
-// Reuse proxy instance between renders to be able to do deep equals between
-// RemoteLoader prop transitions and know whether the user proxies changed.
-const StateProxy = createStateProxy();
-
 let domContainer;
-let loaderRef;
-let prevState;
+let StateProxy;
 
 const createDomContainer = () => {
   if (!domContainer) {
@@ -30,12 +25,14 @@ export function mount({
     ? document.querySelector(containerQuerySelector)
     : createDomContainer();
 
+  // Reuse proxy instance between renders to be able to do deep equals between
+  // RemoteLoader prop transitions and know whether the user proxies changed.
+  if (!StateProxy) {
+    StateProxy = createStateProxy();
+  }
+
   render(
     <RemoteLoader
-      ref={ref => {
-        loaderRef = ref;
-      }}
-      initialState={prevState}
       components={components}
       fixtures={fixtures}
       proxies={[
@@ -46,14 +43,4 @@ export function mount({
     />,
     container
   );
-}
-
-export function unmount() {
-  if (domContainer) {
-    if (loaderRef) {
-      prevState = loaderRef.state;
-    }
-
-    unmountComponentAtNode(domContainer);
-  }
 }

--- a/packages/react-cosmos-loader/src/mount.js
+++ b/packages/react-cosmos-loader/src/mount.js
@@ -4,6 +4,8 @@ import RemoteLoader from './components/RemoteLoader';
 import createStateProxy from 'react-cosmos-state-proxy';
 
 let domContainer;
+let loaderRef;
+let prevState;
 
 const createDomContainer = () => {
   if (!domContainer) {
@@ -26,6 +28,10 @@ export function mount({
 
   render(
     <RemoteLoader
+      ref={ref => {
+        loaderRef = ref;
+      }}
+      initialState={prevState}
       components={components}
       fixtures={fixtures}
       proxies={[
@@ -40,6 +46,10 @@ export function mount({
 
 export function unmount() {
   if (domContainer) {
+    if (loaderRef) {
+      prevState = loaderRef.state;
+    }
+
     unmountComponentAtNode(domContainer);
   }
 }

--- a/packages/react-cosmos-loader/yarn.lock
+++ b/packages/react-cosmos-loader/yarn.lock
@@ -10,6 +10,10 @@ core-js@^1.0.0:
   version "1.2.7"
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-1.2.7.tgz#652294c14651db28fa93bd2d5ff2983a4f08c636"
 
+deep-equal@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/deep-equal/-/deep-equal-1.0.1.tgz#f5d260292b660e084eff4cdbc9f08ad3247448b5"
+
 encoding@^0.1.11:
   version "0.1.12"
   resolved "https://registry.yarnpkg.com/encoding/-/encoding-0.1.12.tgz#538b66f3ee62cd1ab51ec323829d1f9480c74beb"
@@ -47,9 +51,25 @@ js-tokens@^3.0.0:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-3.0.2.tgz#9866df395102130e38f7f996bceb65443209c25b"
 
+lodash.isempty@^4.4.0:
+  version "4.4.0"
+  resolved "https://registry.yarnpkg.com/lodash.isempty/-/lodash.isempty-4.4.0.tgz#6f86cbedd8be4ec987be9aaf33c9684db1b31e7e"
+
+lodash.isequal@^4.4.0:
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/lodash.isequal/-/lodash.isequal-4.5.0.tgz#415c4478f2bcc30120c22ce10ed3226f7d3e18e0"
+
+lodash.isplainobject@^4.0.6:
+  version "4.0.6"
+  resolved "https://registry.yarnpkg.com/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz#7c526a52d89b45c45cc690b88163be0497f550cb"
+
 lodash.merge@^4.6.0:
   version "4.6.0"
   resolved "https://registry.yarnpkg.com/lodash.merge/-/lodash.merge-4.6.0.tgz#69884ba144ac33fe699737a6086deffadd0f89c5"
+
+lodash.omit@^4.5.0:
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/lodash.omit/-/lodash.omit-4.5.0.tgz#6eb19ae5a1ee1dd9df0b969e66ce0b7fa30b5e60"
 
 loose-envify@^1.0.0, loose-envify@^1.3.1:
   version "1.3.1"
@@ -81,9 +101,36 @@ prop-types@^15.5.10:
     fbjs "^0.8.9"
     loose-envify "^1.3.1"
 
+react-cosmos-state-proxy@^2.0.0-rc.1:
+  version "2.0.0-rc.1"
+  resolved "https://registry.yarnpkg.com/react-cosmos-state-proxy/-/react-cosmos-state-proxy-2.0.0-rc.1.tgz#3a7f079caf7b551a9c60efe94e2b35e194b817fb"
+  dependencies:
+    lodash.isempty "^4.4.0"
+    lodash.isequal "^4.4.0"
+    lodash.omit "^4.5.0"
+    prop-types "^15.5.10"
+    react-cosmos-utils "^2.0.0-rc.1"
+
+react-cosmos-utils@^2.0.0-rc.1:
+  version "2.0.0-rc.1"
+  resolved "https://registry.yarnpkg.com/react-cosmos-utils/-/react-cosmos-utils-2.0.0-rc.1.tgz#3d98bf3d8995d6b07e184e40e5906faf4ee30a25"
+  dependencies:
+    lodash.isplainobject "^4.0.6"
+    prop-types "^15.5.10"
+    resolve-from "^3.0.0"
+    slash "^1.0.0"
+
+resolve-from@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/resolve-from/-/resolve-from-3.0.0.tgz#b22c7af7d9d6881bc8b6e653335eebcb0a188748"
+
 setimmediate@^1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/setimmediate/-/setimmediate-1.0.5.tgz#290cbb232e306942d7d7ea9b83732ab7856f8285"
+
+slash@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/slash/-/slash-1.0.0.tgz#c41f2f6c39fc16d1cd17ad4b5d896114ae470d55"
 
 ua-parser-js@^0.7.9:
   version "0.7.14"

--- a/packages/react-cosmos-webpack/src/__tests__/loader-entry.js
+++ b/packages/react-cosmos-webpack/src/__tests__/loader-entry.js
@@ -1,4 +1,4 @@
-import { mount, unmount } from 'react-cosmos-loader';
+import { mount } from 'react-cosmos-loader';
 import '../loader-entry';
 
 jest.mock('react-cosmos-loader', () => ({

--- a/packages/react-cosmos-webpack/src/__tests__/loader-entry.js
+++ b/packages/react-cosmos-webpack/src/__tests__/loader-entry.js
@@ -23,10 +23,6 @@ jest.mock('../user-modules', () => ({
 
 const options = mount.mock.calls[0][0];
 
-test('unmount prev loader', () => {
-  expect(unmount).toHaveBeenCalled();
-});
-
 test('starts loader', () => {
   expect(mount).toHaveBeenCalled();
 });

--- a/packages/react-cosmos-webpack/src/__tests__/loader-webpack-config.js
+++ b/packages/react-cosmos-webpack/src/__tests__/loader-webpack-config.js
@@ -54,6 +54,7 @@ beforeEach(() => {
 
   webpack = require('webpack');
   webpack.__setPluginMock('DefinePlugin', DefinePlugin);
+  webpack.__setPluginMock('NoEmitOnErrorsPlugin', () => {});
   webpack.__setPluginMock(
     'HotModuleReplacementPlugin',
     HotModuleReplacementPlugin

--- a/packages/react-cosmos-webpack/src/loader-entry.js
+++ b/packages/react-cosmos-webpack/src/loader-entry.js
@@ -21,15 +21,12 @@ const {
   normalizeComponents,
   normalizeFixtures
 } = require('./normalize-modules');
-const { mount, unmount } = require('react-cosmos-loader');
+const { mount } = require('react-cosmos-loader');
 
 // eslint-disable-next-line no-undef
 const { containerQuerySelector } = COSMOS_CONFIG;
 
 const start = () => {
-  // Unmounting needs to be done before importing new modules after HMR
-  unmount();
-
   // Module is imported whenever this function is called, making sure the
   // lastest module version is used after a HMR update
   const getUserModules = require('./user-modules').default;

--- a/packages/react-cosmos-webpack/src/loader-entry.js
+++ b/packages/react-cosmos-webpack/src/loader-entry.js
@@ -50,3 +50,6 @@ if (module.hot) {
     start();
   });
 }
+
+// Hook for Cypress to simulate a HMR update
+window.__startCosmosLoader = start;

--- a/packages/react-cosmos-webpack/src/loader-webpack-config.js
+++ b/packages/react-cosmos-webpack/src/loader-webpack-config.js
@@ -72,17 +72,18 @@ export default function getLoaderWebpackConfig({
       'process.env': {
         NODE_ENV: JSON.stringify(shouldExport ? 'production' : 'development')
       }
-    })
-  );
-
-  plugins.push(
+    }),
     new webpack.DefinePlugin({
       COSMOS_CONFIG: JSON.stringify({
         // Config options that are available inside the client bundle. Warning:
         // Must be serializable!
         containerQuerySelector
       })
-    })
+    }),
+    // Important: Without this webpack tries to apply hot updates for broken
+    // builds and results in duplicate React nodes attached
+    // See https://github.com/webpack/webpack/issues/2117
+    new webpack.NoEmitOnErrorsPlugin()
   );
 
   if (hot && !shouldExport) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,6 +2,12 @@
 # yarn lockfile v1
 
 
+"@cypress/coffee-script@0.1.2":
+  version "0.1.2"
+  resolved "https://registry.yarnpkg.com/@cypress/coffee-script/-/coffee-script-0.1.2.tgz#2721cf60ef65ce47b3895aa0b8e84771868bc011"
+  dependencies:
+    coffee-script "1.12.5"
+
 JSONStream@^1.0.4:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/JSONStream/-/JSONStream-1.3.1.tgz#707f761e01dae9e16f1bcf93703b78c70966579a"
@@ -1426,9 +1432,9 @@ code-point-at@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/code-point-at/-/code-point-at-1.1.0.tgz#0d070b4d043a5bea33a2f1a40e2edb3d9a4ccf77"
 
-coffee-script@^1.9.3:
-  version "1.12.7"
-  resolved "https://registry.yarnpkg.com/coffee-script/-/coffee-script-1.12.7.tgz#c05dae0cb79591d05b3070a8433a98c9a89ccc53"
+coffee-script@1.12.5:
+  version "1.12.5"
+  resolved "https://registry.yarnpkg.com/coffee-script/-/coffee-script-1.12.5.tgz#809f4585419112bbfe46a073ad7543af18c27346"
 
 color-convert@^1.3.0, color-convert@^1.9.0:
   version "1.9.0"
@@ -1945,13 +1951,13 @@ currently-unhandled@^0.4.1:
   dependencies:
     array-find-index "^1.0.1"
 
-cypress-cli@^0.13.1:
-  version "0.13.1"
-  resolved "https://registry.yarnpkg.com/cypress-cli/-/cypress-cli-0.13.1.tgz#239371ae7bec161eb12ae2b4c999fd685d38e752"
+cypress-cli@^0.14.0:
+  version "0.14.0"
+  resolved "https://registry.yarnpkg.com/cypress-cli/-/cypress-cli-0.14.0.tgz#008163b453adb82f57996e513c9e6d62ee234f1f"
   dependencies:
+    "@cypress/coffee-script" "0.1.2"
     bluebird "3.3.4"
     chalk "^1.1.0"
-    coffee-script "^1.9.3"
     commander "^2.8.1"
     extract-zip "1.5.0"
     fs-extra "^0.22.1"
@@ -1961,6 +1967,7 @@ cypress-cli@^0.13.1:
     progress "^1.1.8"
     request "^2.60.0"
     request-progress "^0.3.1"
+    semver "^5.4.1"
     through2 "^2.0.0"
     update-notifier "^1.0.3"
     xvfb cypress-io/node-xvfb
@@ -4255,9 +4262,9 @@ lcov-parse@0.0.10:
   version "0.0.10"
   resolved "https://registry.yarnpkg.com/lcov-parse/-/lcov-parse-0.0.10.tgz#1b0b8ff9ac9c7889250582b70b71315d9da6d9a3"
 
-lerna@^2.1.0:
-  version "2.1.2"
-  resolved "https://registry.yarnpkg.com/lerna/-/lerna-2.1.2.tgz#b07eb7a4d7dd7d44a105262fef49b2229301c577"
+lerna@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/lerna/-/lerna-2.2.0.tgz#dcf588f8c8feb57d76b34ef72cfedef23f1b5807"
   dependencies:
     async "^1.5.0"
     chalk "^2.1.0"
@@ -4328,9 +4335,9 @@ levn@^0.3.0, levn@~0.3.0:
     prelude-ls "~1.1.2"
     type-check "~0.3.2"
 
-lint-staged@^4.0.4:
-  version "4.1.3"
-  resolved "https://registry.yarnpkg.com/lint-staged/-/lint-staged-4.1.3.tgz#07c592e4b8dee914450a183c761187dc53d079e2"
+lint-staged@^4.2.1:
+  version "4.2.1"
+  resolved "https://registry.yarnpkg.com/lint-staged/-/lint-staged-4.2.1.tgz#5c79818c500d9b24248dccad4ac9609c01951522"
   dependencies:
     app-root-path "^2.0.0"
     chalk "^2.1.0"
@@ -6982,9 +6989,9 @@ webpack-sources@^1.0.1:
     source-list-map "^2.0.0"
     source-map "~0.5.3"
 
-webpack@^3.5.5:
-  version "3.5.6"
-  resolved "https://registry.yarnpkg.com/webpack/-/webpack-3.5.6.tgz#a492fb6c1ed7f573816f90e00c8fbb5a20cc5c36"
+webpack@^3.6.0:
+  version "3.6.0"
+  resolved "https://registry.yarnpkg.com/webpack/-/webpack-3.6.0.tgz#a89a929fbee205d35a4fa2cc487be9cbec8898bc"
   dependencies:
     acorn "^5.0.0"
     acorn-dynamic-import "^2.0.0"
@@ -7197,7 +7204,7 @@ xtend@^4.0.0, xtend@^4.0.1, xtend@~4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/xtend/-/xtend-4.0.1.tgz#a5c6d532be656e23db820efb943a1f04998d63af"
 
-xvfb@cypress-io/node-xvfb:
+"xvfb@github:cypress-io/node-xvfb":
   version "0.3.0"
   resolved "https://codeload.github.com/cypress-io/node-xvfb/tar.gz/22e3783c31d81ebe64d8c0df491ea00cdc74726a"
 
@@ -7236,6 +7243,24 @@ yargs@^8.0.2:
 yargs@^9.0.0:
   version "9.0.0"
   resolved "https://registry.yarnpkg.com/yargs/-/yargs-9.0.0.tgz#efe5b1ad3f94bdc20423411b90628eeec0b25f3c"
+  dependencies:
+    camelcase "^4.1.0"
+    cliui "^3.2.0"
+    decamelize "^1.1.1"
+    get-caller-file "^1.0.1"
+    os-locale "^2.0.0"
+    read-pkg-up "^2.0.0"
+    require-directory "^2.1.1"
+    require-main-filename "^1.0.1"
+    set-blocking "^2.0.0"
+    string-width "^2.0.0"
+    which-module "^2.0.0"
+    y18n "^3.2.1"
+    yargs-parser "^7.0.0"
+
+yargs@^9.0.1:
+  version "9.0.1"
+  resolved "https://registry.yarnpkg.com/yargs/-/yargs-9.0.1.tgz#52acc23feecac34042078ee78c0c007f5085db4c"
   dependencies:
     camelcase "^4.1.0"
     cliui "^3.2.0"


### PR DESCRIPTION
A regression occurred during the last major refactor of the Loader: Fixture state is no longer preserved after a component is hot reloaded. Hot reloading is a core tenet of Cosmos so I wanted to make sure it's fixed asap and prevented in the future, which is why this is both unit tested and high-level tested with Cypress. The latter should continue to pass even if we rewrite the Loader from scratch.

## Before
![fixture-state-before](https://user-images.githubusercontent.com/250750/30781103-511ebbcc-a119-11e7-9e5e-76899bba075a.gif)

## After
![fixture-state-after](https://user-images.githubusercontent.com/250750/30781102-511e5bfa-a119-11e7-9d30-d80b972b44ef.gif)
