### PR TITLE
Add option for excluding fixture files

### DIFF
--- a/packages/react-cosmos-config/src/index.js
+++ b/packages/react-cosmos-config/src/index.js
@@ -6,9 +6,12 @@ import { importModule } from 'react-cosmos-shared';
 import { moduleExists, resolveUserPath } from 'react-cosmos-shared/lib/server';
 import { log, warn } from './log';
 
+import type { ExcludePatterns } from 'react-cosmos-shared/src/types';
+
 export type Config = {
   rootPath: string,
   fileMatch?: Array<string>,
+  exclude?: ExcludePatterns,
   globalImports: Array<string>,
   hostname: string,
   hot: boolean,

--- a/packages/react-cosmos-shared/src/types.js
+++ b/packages/react-cosmos-shared/src/types.js
@@ -1,0 +1,5 @@
+// @flow
+
+type ExcludePattern = string | RegExp;
+
+export type ExcludePatterns = ExcludePattern | Array<ExcludePattern>;

--- a/packages/react-cosmos-telescope/src/index.js
+++ b/packages/react-cosmos-telescope/src/index.js
@@ -1,3 +1,5 @@
+// @flow
+
 import React from 'react';
 import renderer from 'react-test-renderer';
 import createStateProxy from 'react-cosmos-state-proxy';
@@ -8,9 +10,19 @@ import { findFixtureFiles } from 'react-cosmos-voyager2/lib/server';
 import { getComponents } from 'react-cosmos-voyager2/lib/client';
 import { Loader } from 'react-cosmos-loader';
 
-export default async ({ cosmosConfigPath } = {}) => {
+type Args = {
+  cosmosConfigPath: Array<string>
+};
+
+export default async ({ cosmosConfigPath }: Args) => {
   const cosmosConfig = getCosmosConfig(cosmosConfigPath);
-  const { componentPaths, proxiesPath } = cosmosConfig;
+  const {
+    rootPath,
+    proxiesPath,
+    fileMatch,
+    exclude,
+    componentPaths
+  } = cosmosConfig;
 
   if (componentPaths.length > 0) {
     console.warn(
@@ -30,7 +42,11 @@ export default async ({ cosmosConfigPath } = {}) => {
   ];
 
   test('Cosmos fixtures', async () => {
-    const fixtureFiles = await findFixtureFiles(cosmosConfig);
+    const fixtureFiles = await findFixtureFiles({
+      cwd: rootPath,
+      fileMatch,
+      exclude
+    });
     const fixtureModules = getFixtureModules(fixtureFiles);
     const components = getComponents({ fixtureModules, fixtureFiles });
 

--- a/packages/react-cosmos-voyager2/src/server/__tests__/esm/exclude/__fsmocks__/fixture.js
+++ b/packages/react-cosmos-voyager2/src/server/__tests__/esm/exclude/__fsmocks__/fixture.js
@@ -1,0 +1,10 @@
+// @flow
+
+import React from 'react';
+
+const InlineComponent = () => <span />;
+
+export default {
+  component: InlineComponent,
+  props: {}
+};

--- a/packages/react-cosmos-voyager2/src/server/__tests__/esm/exclude/__fsmocks__/ignored-dir/fixture.js
+++ b/packages/react-cosmos-voyager2/src/server/__tests__/esm/exclude/__fsmocks__/ignored-dir/fixture.js
@@ -1,0 +1,10 @@
+// @flow
+
+import React from 'react';
+
+const InlineComponent = () => <span />;
+
+export default {
+  component: InlineComponent,
+  props: {}
+};

--- a/packages/react-cosmos-voyager2/src/server/__tests__/esm/exclude/__fsmocks__/ignored-file.fixture.js
+++ b/packages/react-cosmos-voyager2/src/server/__tests__/esm/exclude/__fsmocks__/ignored-file.fixture.js
@@ -1,0 +1,10 @@
+// @flow
+
+import React from 'react';
+
+const InlineComponent = () => <span />;
+
+export default {
+  component: InlineComponent,
+  props: {}
+};

--- a/packages/react-cosmos-voyager2/src/server/__tests__/esm/exclude/index.js
+++ b/packages/react-cosmos-voyager2/src/server/__tests__/esm/exclude/index.js
@@ -1,0 +1,38 @@
+// @flow
+
+import { join } from 'path';
+import { findFixtureFiles } from '../../../find-fixture-files';
+
+const { resolve } = require;
+
+describe('ES module / Exclude option (list)', () => {
+  let files;
+
+  beforeEach(async () => {
+    files = await findFixtureFiles({
+      cwd: join(__dirname, '__fsmocks__'),
+      exclude: [/ignored-dir/, /ignored-file/]
+    });
+  });
+
+  it('only finds file that does not match exclude patterns', () => {
+    expect(files).toHaveLength(1);
+    expect(files[0].filePath).toEqual(resolve('./__fsmocks__/fixture'));
+  });
+});
+
+describe('ES module / Exclude option (single)', () => {
+  let files;
+
+  beforeEach(async () => {
+    files = await findFixtureFiles({
+      cwd: join(__dirname, '__fsmocks__'),
+      exclude: /(ignored-dir|ignored-file)/
+    });
+  });
+
+  it('only finds file that does not match exclude patterns', () => {
+    expect(files).toHaveLength(1);
+    expect(files[0].filePath).toEqual(resolve('./__fsmocks__/fixture'));
+  });
+});

--- a/packages/react-cosmos-voyager2/src/server/find-fixture-files.js
+++ b/packages/react-cosmos-voyager2/src/server/find-fixture-files.js
@@ -5,15 +5,14 @@ import micromatch from 'micromatch';
 import promisify from 'util.promisify';
 import { extractComponentsFromFixtureFile } from './extract-components-from-fixture-file';
 
+import type { ExcludePatterns } from 'react-cosmos-shared/src/types';
 import type { FixtureFile } from '../types';
 
 const globAsync = promisify(glob);
 
-type ExcludePattern = string | RegExp;
-
 type Args = ?{
   fileMatch?: Array<string>,
-  exclude?: ExcludePattern | Array<ExcludePattern>,
+  exclude?: ExcludePatterns,
   cwd?: string
 };
 

--- a/packages/react-cosmos-webpack/src/server/__tests__/embed-modules-webpack-loader/new-fixtures.js
+++ b/packages/react-cosmos-webpack/src/server/__tests__/embed-modules-webpack-loader/new-fixtures.js
@@ -3,7 +3,7 @@ import { findFixtureFiles } from 'react-cosmos-voyager2/lib/server';
 // Requiring because embed-modules-webpack-loader is a CJS module
 const embedModules = require('../../embed-modules-webpack-loader');
 
-// The values of these mocks doesn't matter, we check for identity
+// The values of these mocks don't matter, we check for identity
 const mockFileMatch = [];
 const mockExclude = [];
 

--- a/packages/react-cosmos-webpack/src/server/__tests__/embed-modules-webpack-loader/new-fixtures.js
+++ b/packages/react-cosmos-webpack/src/server/__tests__/embed-modules-webpack-loader/new-fixtures.js
@@ -3,11 +3,14 @@ import { findFixtureFiles } from 'react-cosmos-voyager2/lib/server';
 // Requiring because embed-modules-webpack-loader is a CJS module
 const embedModules = require('../../embed-modules-webpack-loader');
 
+// The values of these mocks doesn't matter, we check for identity
 const mockFileMatch = [];
+const mockExclude = [];
 
 jest.mock('react-cosmos-config', () => () => ({
   rootPath: 'MOCK_ROOT_PATH',
   fileMatch: mockFileMatch,
+  exclude: mockExclude,
   componentPaths: [],
   proxiesPath: require.resolve('../__fsmocks__/cosmos.proxies')
 }));
@@ -77,6 +80,10 @@ it('calls findFixtureFiles with fileMatch with rootPath as cwd', () => {
 
 it('calls findFixtureFiles with fileMatch config', () => {
   expect(findFixtureFiles.mock.calls[0][0].fileMatch).toBe(mockFileMatch);
+});
+
+it('calls findFixtureFiles with exclude config', () => {
+  expect(findFixtureFiles.mock.calls[0][0].exclude).toBe(mockExclude);
 });
 
 it('injects fixture modules', () => {

--- a/packages/react-cosmos-webpack/src/server/embed-modules-webpack-loader.js
+++ b/packages/react-cosmos-webpack/src/server/embed-modules-webpack-loader.js
@@ -55,7 +55,7 @@ module.exports = async function embedModules(source: string) {
 };
 
 async function getNormalizedModules(cosmosConfig) {
-  const { rootPath, fileMatch, componentPaths } = cosmosConfig;
+  const { rootPath, fileMatch, exclude, componentPaths } = cosmosConfig;
 
   if (componentPaths.length > 0) {
     console.warn(
@@ -84,7 +84,11 @@ async function getNormalizedModules(cosmosConfig) {
     return { fixtureFiles, deprecatedComponentModules: components };
   }
 
-  const fixtureFiles = await findFixtureFiles({ cwd: rootPath, fileMatch });
+  const fixtureFiles = await findFixtureFiles({
+    cwd: rootPath,
+    fileMatch,
+    exclude
+  });
 
   return {
     fixtureFiles,


### PR DESCRIPTION
New `exclude` option for omitting fixture files. Can be one or a list of regular expressions or strings.