### PR TITLE
Allow namespacing of fixtures in tree view

### DIFF
--- a/packages/react-cosmos-playground/src/components/FixtureList/__fixtures__/nested-data.js
+++ b/packages/react-cosmos-playground/src/components/FixtureList/__fixtures__/nested-data.js
@@ -7,7 +7,12 @@ export default {
     fixtures: {
       'dirA/Component1': ['fixtureA', 'fixtureB'],
       'dirB/Component2': ['fixtureA', 'fixtureB'],
-      'dirB/Component3': ['fixtureA', 'fixtureB'],
+      'dirB/Component3': [
+        'Some folder/fixtureA',
+        'Some folder/fixtureB',
+        'Another folder/fixtureC',
+        'fixtureD'
+      ],
       'dirB/subdirA/Component4': ['fixtureA', 'fixtureB']
     },
     urlParams: {},

--- a/packages/react-cosmos-playground/src/components/FixtureList/__tests__/data-mapper.js
+++ b/packages/react-cosmos-playground/src/components/FixtureList/__tests__/data-mapper.js
@@ -1,13 +1,13 @@
 import fixturesToTreeData from '../data-mapper';
 
-const input = {
-  'dirA/Component1': ['fixtureA', 'fixtureB'],
-  'dirB/Component2': ['fixtureA', 'fixtureB'],
-  'dirB/Component3': ['fixtureA', 'fixtureB'],
-  'dirB/subdirA/Component4': ['fixtureA', 'fixtureB']
-};
-
 test('transforms fixture data structure to tree data structure', () => {
+  const input = {
+    'dirA/Component1': ['fixtureA', 'fixtureB'],
+    'dirB/Component2': ['fixtureA', 'fixtureB'],
+    'dirB/Component3': ['fixtureA', 'fixtureB'],
+    'dirB/subdirA/Component4': ['fixtureA', 'fixtureB']
+  };
+
   const expected = [
     {
       name: 'dirA',
@@ -117,6 +117,113 @@ test('transforms fixture data structure to tree data structure', () => {
                   }
                 }
               ]
+            }
+          ]
+        }
+      ]
+    }
+  ];
+
+  expect(fixturesToTreeData(input)).toEqual(expected);
+});
+
+test('deals with components with namespaced fixtures', () => {
+  const input = {
+    'dirA/Component1': ['fixtureA', 'fixtureB'],
+    'dirB/Component2': [
+      'Some folder/fixtureA',
+      'Some folder/fixtureB',
+      'Another folder/fixtureC',
+      'fixtureD'
+    ]
+  };
+
+  const expected = [
+    {
+      name: 'dirA',
+      type: 'directory',
+      expanded: true,
+      children: [
+        {
+          name: 'Component1',
+          type: 'component',
+          expanded: true,
+          children: [
+            {
+              name: 'fixtureA',
+              type: 'fixture',
+              urlParams: {
+                component: 'dirA/Component1',
+                fixture: 'fixtureA'
+              }
+            },
+            {
+              name: 'fixtureB',
+              type: 'fixture',
+              urlParams: {
+                component: 'dirA/Component1',
+                fixture: 'fixtureB'
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      name: 'dirB',
+      type: 'directory',
+      expanded: true,
+      children: [
+        {
+          name: 'Component2',
+          type: 'component',
+          expanded: true,
+          children: [
+            {
+              name: 'Some folder',
+              type: 'fixtureDirectory',
+              expanded: true,
+              children: [
+                {
+                  name: 'fixtureA',
+                  type: 'fixture',
+                  urlParams: {
+                    component: 'dirB/Component2',
+                    fixture: 'Some folder/fixtureA'
+                  }
+                },
+                {
+                  name: 'fixtureB',
+                  type: 'fixture',
+                  urlParams: {
+                    component: 'dirB/Component2',
+                    fixture: 'Some folder/fixtureB'
+                  }
+                }
+              ]
+            },
+            {
+              name: 'Another folder',
+              type: 'fixtureDirectory',
+              expanded: true,
+              children: [
+                {
+                  name: 'fixtureC',
+                  type: 'fixture',
+                  urlParams: {
+                    component: 'dirB/Component2',
+                    fixture: 'Another folder/fixtureC'
+                  }
+                }
+              ]
+            },
+            {
+              name: 'fixtureD',
+              type: 'fixture',
+              urlParams: {
+                component: 'dirB/Component2',
+                fixture: 'fixtureD'
+              }
             }
           ]
         }

--- a/packages/react-cosmos-playground/src/components/SvgIcon/index.js
+++ b/packages/react-cosmos-playground/src/components/SvgIcon/index.js
@@ -17,6 +17,13 @@ export const FolderIcon = () => (
   <SvgIcon d="M10 4H4c-1.1 0-1.99.9-1.99 2L2 18c0 1.1.9 2 2 2h16c1.1 0 2-.9 2-2V8c0-1.1-.9-2-2-2h-8l-2-2z" />
 );
 
+export const FixtureFolderIcon = () => (
+  <svg viewBox="0 0 24 24">
+    <path d="M0 0h24v24H0V0z" fill="none" />
+    <path d="M20 6h-8l-2-2H4c-1.1 0-2 .9-2 2v12c0 1.1.9 2 2 2h16c1.1 0 2-.9 2-2V8c0-1.1-.9-2-2-2zm-2.06 11L15 15.28 12.06 17l.78-3.33-2.59-2.24 3.41-.29L15 8l1.34 3.14 3.41.29-2.59 2.24.78 3.33z" />
+  </svg>
+);
+
 // https://www.shareicon.net/react-logo-react-js-js-640324
 export const ComponentIcon = () => (
   <svg viewBox="0 0 426 426">

--- a/packages/react-cosmos-playground/src/components/Tree/index.js
+++ b/packages/react-cosmos-playground/src/components/Tree/index.js
@@ -2,6 +2,7 @@ import React from 'react';
 import { arrayOf, oneOf, shape, number, string, func, bool } from 'prop-types';
 import {
   FolderIcon,
+  FixtureFolderIcon,
   ComponentIcon,
   RightArrowIcon,
   DownArrowIcon
@@ -62,6 +63,19 @@ const FuzzyHighligher = ({ searchText, textToHighlight }) => {
   return <span>{highlighted}</span>;
 };
 
+const Icon = ({ type }) => {
+  switch (type) {
+    case 'component':
+      return <ComponentIcon />;
+    case 'directory':
+      return <FolderIcon />;
+    case 'fixtureDirectory':
+      return <FixtureFolderIcon />;
+    default:
+      throw new Error(`Unexpected icon type ${type}`);
+  }
+};
+
 const TreeFolder = ({
   node,
   onSelect,
@@ -89,7 +103,7 @@ const TreeFolder = ({
         <span className={styles.arrowIcon}>
           {node.expanded ? <DownArrowIcon /> : <RightArrowIcon />}
         </span>
-        {node.type === 'component' ? <ComponentIcon /> : <FolderIcon />}
+        <Icon type={node.type} />
         <FuzzyHighligher searchText={searchText} textToHighlight={node.name} />
       </div>
       <Tree


### PR DESCRIPTION
If users have the `namespace` attribute on a fixture set, then instead of rendering a fixture name as "my namespace/fixture name", we render fixture directories instead.

Only allows a single level of nesting.

I added a different fixture directory icon, didn't really know which one to pick. This can probably be improved, perhaps we want something with some angled brackets instead of a star.

<img width="271" alt="screen shot 2017-10-30 at 11 52 58 am" src="https://user-images.githubusercontent.com/4144910/32154055-f3f0adc2-bd68-11e7-80bb-870c0c25734a.png">