### PR TITLE
Enable HMR in xhr-proxy

### DIFF
--- a/packages/react-cosmos-xhr-proxy/src/index.js
+++ b/packages/react-cosmos-xhr-proxy/src/index.js
@@ -17,6 +17,14 @@ export default function createXhrProxy(options) {
     constructor(props) {
       super(props);
 
+      if (module.hot) {
+        module.hot.status(status => {
+          if (status === 'check') {
+            xhrMock.teardown();
+          }
+        });
+      }
+
       this.mock();
     }
 


### PR DESCRIPTION
Fixes https://github.com/react-cosmos/react-cosmos/issues/430

Looks like xhr-mock 2 is [still in preview](https://github.com/jameslnewell/xhr-mock/blob/master/CHANGELOG.md), so I implemented the solution proposed in the issue.

Credit and thanks to @dfedynich