### PR TITLE
use resolveUserPath instead of require.resolve for non .js extensions

### DIFF
--- a/packages/react-cosmos-voyager2/package.json
+++ b/packages/react-cosmos-voyager2/package.json
@@ -14,6 +14,7 @@
   "main": "lib/index.js",
   "scripts": {},
   "dependencies": {
+    "react-cosmos-shared": "^3.0.0-beta.8",
     "babel-types": "^6.26.0",
     "babylon": "^6.18.0",
     "commondir": "^1.0.1",

--- a/packages/react-cosmos-voyager2/src/server/extract-components-from-fixture-file.js
+++ b/packages/react-cosmos-voyager2/src/server/extract-components-from-fixture-file.js
@@ -6,6 +6,7 @@ import promisify from 'util.promisify';
 import * as babylon from 'babylon';
 import * as t from 'babel-types';
 
+import { resolveUserPath } from 'react-cosmos-shared/lib/server';
 import type { ComponentInfo } from '../types';
 
 const readFileAsync = promisify(fs.readFile);
@@ -99,8 +100,7 @@ export async function extractComponentsFromFixtureFile(
         }
 
         // TODO: What if path isn't relative?
-        const absPath = path.join(path.dirname(fixturePath), importPath);
-        filePath = require.resolve(absPath);
+        filePath = resolveUserPath(path.dirname(fixturePath), importPath);
       } catch (err) {
         // TODO: Allow user to see these errors when debugging
         // console.log(err.message);


### PR DESCRIPTION
addresses #505 
simply replace require.resolve with the shared util function so it no longer throws when no .js file is found at the path.
