### PR TITLE
Generate config automatically for create-react-app

### DIFF
--- a/packages/react-cosmos-config/package.json
+++ b/packages/react-cosmos-config/package.json
@@ -12,5 +12,10 @@
     "react-cosmos-shared": "^3.0.0-beta.13",
     "yargs": "^9.0.1"
   },
+  "devDependencies": {
+    "mkdirp": "^0.5.1",
+    "rimraf": "^2.6.2",
+    "touch": "^3.1.0"
+  },
   "xo": false
 }

--- a/packages/react-cosmos-config/src/__tests__/arg-path/custom-root-path.js
+++ b/packages/react-cosmos-config/src/__tests__/arg-path/custom-root-path.js
@@ -1,7 +1,7 @@
 // @flow
 
 import path from 'path';
-import getCosmosConfig from '../../';
+import { getCosmosConfig } from '../../';
 
 const configPath = require.resolve(
   './__fsmocks__/cosmos-custom-root.config.js'

--- a/packages/react-cosmos-config/src/__tests__/arg-path/index.js
+++ b/packages/react-cosmos-config/src/__tests__/arg-path/index.js
@@ -1,7 +1,7 @@
 // @flow
 
 import path from 'path';
-import getCosmosConfig from '../../';
+import { getCosmosConfig } from '../../';
 
 const configPath = require.resolve('./__fsmocks__/cosmos.config.js');
 const rootPath = path.dirname(configPath);

--- a/packages/react-cosmos-config/src/__tests__/cli-path/custom-path/index.js
+++ b/packages/react-cosmos-config/src/__tests__/cli-path/custom-path/index.js
@@ -1,7 +1,7 @@
 // @flow
 
 import path from 'path';
-import getCosmosConfig from '../../../';
+import { getCosmosConfig } from '../../../';
 
 jest.mock('yargs', () => ({ argv: { config: 'nested/cosmos.config' } }));
 

--- a/packages/react-cosmos-config/src/__tests__/cli-path/default-path/index.js
+++ b/packages/react-cosmos-config/src/__tests__/cli-path/default-path/index.js
@@ -1,7 +1,7 @@
 // @flow
 
 import path from 'path';
-import getCosmosConfig from '../../../';
+import { getCosmosConfig } from '../../../';
 
 jest.mock('yargs', () => ({ argv: {} }));
 

--- a/packages/react-cosmos-config/src/__tests__/cli-path/no-config-wrong-path/index.js
+++ b/packages/react-cosmos-config/src/__tests__/cli-path/no-config-wrong-path/index.js
@@ -1,7 +1,7 @@
 // @flow
 
 import path from 'path';
-import getCosmosConfig from '../../../';
+import { getCosmosConfig } from '../../../';
 
 jest.mock('yargs', () => ({ argv: { config: 'cozmos.config' } }));
 

--- a/packages/react-cosmos-config/src/__tests__/cli-path/no-config/index.js
+++ b/packages/react-cosmos-config/src/__tests__/cli-path/no-config/index.js
@@ -1,7 +1,7 @@
 // @flow
 
 import path from 'path';
-import getCosmosConfig from '../../../';
+import { getCosmosConfig } from '../../../';
 
 jest.mock('yargs', () => ({ argv: {} }));
 

--- a/packages/react-cosmos-config/src/__tests__/cli-path/no-config/index.js
+++ b/packages/react-cosmos-config/src/__tests__/cli-path/no-config/index.js
@@ -1,7 +1,7 @@
 // @flow
 
 import path from 'path';
-import { getCosmosConfig } from '../../../';
+import { getCosmosConfig, hasUserCosmosConfig } from '../../../';
 
 jest.mock('yargs', () => ({ argv: {} }));
 
@@ -25,5 +25,9 @@ describe('[CLI path] when no config exists', () => {
       rootPath: mocksPath,
       webpackConfigPath: path.join(mocksPath, 'webpack.config')
     });
+  });
+
+  it('reports users has no config', () => {
+    expect(hasUserCosmosConfig()).toBe(false);
   });
 });

--- a/packages/react-cosmos-config/src/__tests__/generate/create-react-app/index.js
+++ b/packages/react-cosmos-config/src/__tests__/generate/create-react-app/index.js
@@ -1,0 +1,46 @@
+// @flow
+
+import path from 'path';
+import mkdirp from 'mkdirp';
+import touch from 'touch';
+import rimraf from 'rimraf';
+import { generateCosmosConfig } from '../../../';
+
+jest.mock('yargs', () => ({ argv: {} }));
+
+// Note: __fsoutput__ are in Jest's watchPathIgnorePatterns
+const outputPath = path.join(__dirname, '__fsoutput__');
+const craWebpackConfigPath = path.join(
+  outputPath,
+  'node_modules/react-scripts/config/webpack.config.dev'
+);
+const cosmosConfigPath = path.join(outputPath, 'cosmos.config.js');
+
+beforeEach(() => {
+  global.process.cwd = () => outputPath;
+
+  mkdirp.sync(path.dirname(craWebpackConfigPath));
+  touch.sync(craWebpackConfigPath);
+});
+
+afterEach(() => {
+  rimraf.sync(path.join(outputPath, 'node_modules'));
+  rimraf.sync(cosmosConfigPath);
+});
+
+describe('Create React App config generation', () => {
+  it('returns correct name', () => {
+    const generatedConfigFor = generateCosmosConfig();
+    expect(generatedConfigFor).toBe('Create React App');
+  });
+
+  it('creates config file', () => {
+    generateCosmosConfig();
+    expect(require(cosmosConfigPath)).toEqual({
+      containerQuerySelector: '#root',
+      webpackConfigPath: 'react-scripts/config/webpack.config.dev',
+      publicPath: 'public',
+      proxiesPath: 'src/cosmos.proxies'
+    });
+  });
+});

--- a/packages/react-cosmos-config/src/config-templates.js
+++ b/packages/react-cosmos-config/src/config-templates.js
@@ -1,0 +1,10 @@
+// @flow
+
+export const CRA_COSMOS_CONFIG = `module.exports = {
+  containerQuerySelector: '#root',
+  webpackConfigPath: 'react-scripts/config/webpack.config.dev',
+  publicPath: 'public',
+  // Optional: Create this file when you begin adding proxies
+  proxiesPath: 'src/cosmos.proxies'
+};
+`;

--- a/packages/react-cosmos-config/src/index.js
+++ b/packages/react-cosmos-config/src/index.js
@@ -47,7 +47,7 @@ const defaults = {
   fixturePaths: []
 };
 
-export default function getCosmosConfig(cosmosConfigPath?: string): Config {
+export function getCosmosConfig(cosmosConfigPath?: string): Config {
   const configPath =
     cosmosConfigPath ||
     resolveUserPath(process.cwd(), argv.config || 'cosmos.config');

--- a/packages/react-cosmos-scripts/src/__tests__/upgrade-fixtures.js
+++ b/packages/react-cosmos-scripts/src/__tests__/upgrade-fixtures.js
@@ -5,7 +5,7 @@ import upgradeFixtures from '../upgrade-fixtures';
 import { addComponentToFixture } from '../transforms/add-component-to-fixture';
 
 jest.mock('react-cosmos-config', () => ({
-  hasCosmosConfig: () => true,
+  hasUserCosmosConfig: () => true,
   getCosmosConfig: jest.fn(() => ({
     componentPaths: ['foo']
   }))

--- a/packages/react-cosmos-scripts/src/__tests__/upgrade-fixtures.js
+++ b/packages/react-cosmos-scripts/src/__tests__/upgrade-fixtures.js
@@ -4,11 +4,12 @@ import { readFileSync, writeFileSync } from 'fs';
 import upgradeFixtures from '../upgrade-fixtures';
 import { addComponentToFixture } from '../transforms/add-component-to-fixture';
 
-jest.mock('react-cosmos-config', () =>
-  jest.fn(() => ({
+jest.mock('react-cosmos-config', () => ({
+  hasCosmosConfig: () => true,
+  getCosmosConfig: jest.fn(() => ({
     componentPaths: ['foo']
   }))
-);
+}));
 
 const mockComponents = {
   'ill/shared/emoji-block': '/path/to/components/ill/shared/emoji-block.js',

--- a/packages/react-cosmos-scripts/src/upgrade-fixtures.js
+++ b/packages/react-cosmos-scripts/src/upgrade-fixtures.js
@@ -4,7 +4,7 @@ import fs from 'fs';
 import path from 'path';
 import camelCase from 'lodash.camelcase';
 import upperFirst from 'lodash.upperfirst';
-import getCosmosConfig from 'react-cosmos-config';
+import { getCosmosConfig } from 'react-cosmos-config';
 import getFilePaths from 'react-cosmos-voyager';
 import { addComponentToFixture } from './transforms/add-component-to-fixture';
 

--- a/packages/react-cosmos-telescope/src/index.js
+++ b/packages/react-cosmos-telescope/src/index.js
@@ -5,7 +5,7 @@ import renderer from 'react-test-renderer';
 import createStateProxy from 'react-cosmos-state-proxy';
 import { importModule } from 'react-cosmos-shared';
 import { moduleExists } from 'react-cosmos-shared/lib/server';
-import getCosmosConfig from 'react-cosmos-config';
+import { getCosmosConfig } from 'react-cosmos-config';
 import { findFixtureFiles } from 'react-cosmos-voyager2/lib/server';
 import { getComponents } from 'react-cosmos-voyager2/lib/client';
 import { Loader } from 'react-cosmos-loader';

--- a/packages/react-cosmos/src/server/__tests__/embed-modules-webpack-loader/new-fixtures.js
+++ b/packages/react-cosmos/src/server/__tests__/embed-modules-webpack-loader/new-fixtures.js
@@ -8,7 +8,7 @@ const mockFileMatch = [];
 const mockExclude = [];
 
 jest.mock('react-cosmos-config', () => ({
-  hasCosmosConfig: () => true,
+  hasUserCosmosConfig: () => true,
   getCosmosConfig: () => ({
     rootPath: 'MOCK_ROOT_PATH',
     fileMatch: mockFileMatch,

--- a/packages/react-cosmos/src/server/__tests__/embed-modules-webpack-loader/new-fixtures.js
+++ b/packages/react-cosmos/src/server/__tests__/embed-modules-webpack-loader/new-fixtures.js
@@ -7,12 +7,15 @@ const embedModules = require('../../embed-modules-webpack-loader');
 const mockFileMatch = [];
 const mockExclude = [];
 
-jest.mock('react-cosmos-config', () => () => ({
-  rootPath: 'MOCK_ROOT_PATH',
-  fileMatch: mockFileMatch,
-  exclude: mockExclude,
-  componentPaths: [],
-  proxiesPath: require.resolve('../__fsmocks__/cosmos.proxies')
+jest.mock('react-cosmos-config', () => ({
+  hasCosmosConfig: () => true,
+  getCosmosConfig: () => ({
+    rootPath: 'MOCK_ROOT_PATH',
+    fileMatch: mockFileMatch,
+    exclude: mockExclude,
+    componentPaths: [],
+    proxiesPath: require.resolve('../__fsmocks__/cosmos.proxies')
+  })
 }));
 
 const mockFixtureFiles = [

--- a/packages/react-cosmos/src/server/__tests__/embed-modules-webpack-loader/old-fixtures.js
+++ b/packages/react-cosmos/src/server/__tests__/embed-modules-webpack-loader/old-fixtures.js
@@ -2,7 +2,7 @@
 const embedModules = require('../../embed-modules-webpack-loader');
 
 jest.mock('react-cosmos-config', () => ({
-  hasCosmosConfig: () => true,
+  hasUserCosmosConfig: () => true,
   getCosmosConfig: () => ({
     componentPaths: ['/path/to/components'],
     proxiesPath: require.resolve('../__fsmocks__/cosmos.proxies')

--- a/packages/react-cosmos/src/server/__tests__/embed-modules-webpack-loader/old-fixtures.js
+++ b/packages/react-cosmos/src/server/__tests__/embed-modules-webpack-loader/old-fixtures.js
@@ -1,9 +1,12 @@
 // Requiring because embed-modules-webpack-loader is a CJS module
 const embedModules = require('../../embed-modules-webpack-loader');
 
-jest.mock('react-cosmos-config', () => () => ({
-  componentPaths: ['/path/to/components'],
-  proxiesPath: require.resolve('../__fsmocks__/cosmos.proxies')
+jest.mock('react-cosmos-config', () => ({
+  hasCosmosConfig: () => true,
+  getCosmosConfig: () => ({
+    componentPaths: ['/path/to/components'],
+    proxiesPath: require.resolve('../__fsmocks__/cosmos.proxies')
+  })
 }));
 
 jest.mock('react-cosmos-voyager', () => () => ({

--- a/packages/react-cosmos/src/server/__tests__/export.js
+++ b/packages/react-cosmos/src/server/__tests__/export.js
@@ -8,11 +8,14 @@ import startExport from '../export';
 const mockRootPath = __dirname;
 const mockOutputPath = path.join(__dirname, './__fsoutput__/export');
 
-jest.mock('react-cosmos-config', () => () => ({
-  rootPath: mockRootPath,
-  outputPath: mockOutputPath,
-  globalImports: [],
-  componentPaths: []
+jest.mock('react-cosmos-config', () => ({
+  hasCosmosConfig: () => true,
+  getCosmosConfig: () => ({
+    rootPath: mockRootPath,
+    outputPath: mockOutputPath,
+    globalImports: [],
+    componentPaths: []
+  })
 }));
 
 jest.mock('webpack', () =>

--- a/packages/react-cosmos/src/server/__tests__/export.js
+++ b/packages/react-cosmos/src/server/__tests__/export.js
@@ -9,7 +9,7 @@ const mockRootPath = __dirname;
 const mockOutputPath = path.join(__dirname, './__fsoutput__/export');
 
 jest.mock('react-cosmos-config', () => ({
-  hasCosmosConfig: () => true,
+  hasUserCosmosConfig: () => true,
   getCosmosConfig: () => ({
     rootPath: mockRootPath,
     outputPath: mockOutputPath,

--- a/packages/react-cosmos/src/server/__tests__/extend-webpack-config/export.js
+++ b/packages/react-cosmos/src/server/__tests__/extend-webpack-config/export.js
@@ -1,7 +1,7 @@
 import extendWebpackConfig from '../../extend-webpack-config';
 
 jest.mock('react-cosmos-config', () => ({
-  hasCosmosConfig: () => true,
+  hasUserCosmosConfig: () => true,
   getCosmosConfig: () => ({
     componentPaths: ['src/components'],
     fixturePaths: ['test/fixtures'],

--- a/packages/react-cosmos/src/server/__tests__/extend-webpack-config/export.js
+++ b/packages/react-cosmos/src/server/__tests__/extend-webpack-config/export.js
@@ -1,13 +1,16 @@
 import extendWebpackConfig from '../../extend-webpack-config';
 
-jest.mock('react-cosmos-config', () => () => ({
-  componentPaths: ['src/components'],
-  fixturePaths: ['test/fixtures'],
-  ignore: [],
-  globalImports: ['./global.css'],
-  hot: true,
-  outputPath: '__mock__outputPath',
-  containerQuerySelector: '__mock__containerQuerySelector'
+jest.mock('react-cosmos-config', () => ({
+  hasCosmosConfig: () => true,
+  getCosmosConfig: () => ({
+    componentPaths: ['src/components'],
+    fixturePaths: ['test/fixtures'],
+    ignore: [],
+    globalImports: ['./global.css'],
+    hot: true,
+    outputPath: '__mock__outputPath',
+    containerQuerySelector: '__mock__containerQuerySelector'
+  })
 }));
 
 const DefinePlugin = jest.fn();

--- a/packages/react-cosmos/src/server/__tests__/extend-webpack-config/general.js
+++ b/packages/react-cosmos/src/server/__tests__/extend-webpack-config/general.js
@@ -1,7 +1,7 @@
 import extendWebpackConfig from '../../extend-webpack-config';
 
 jest.mock('react-cosmos-config', () => ({
-  hasCosmosConfig: () => true,
+  hasUserCosmosConfig: () => true,
   getCosmosConfig: () => ({
     componentPaths: ['src/components'],
     fixturePaths: ['test/fixtures'],

--- a/packages/react-cosmos/src/server/__tests__/extend-webpack-config/general.js
+++ b/packages/react-cosmos/src/server/__tests__/extend-webpack-config/general.js
@@ -1,11 +1,14 @@
 import extendWebpackConfig from '../../extend-webpack-config';
 
-jest.mock('react-cosmos-config', () => () => ({
-  componentPaths: ['src/components'],
-  fixturePaths: ['test/fixtures'],
-  ignore: [],
-  globalImports: ['./global.css'],
-  containerQuerySelector: '__mock__containerQuerySelector'
+jest.mock('react-cosmos-config', () => ({
+  hasCosmosConfig: () => true,
+  getCosmosConfig: () => ({
+    componentPaths: ['src/components'],
+    fixturePaths: ['test/fixtures'],
+    ignore: [],
+    globalImports: ['./global.css'],
+    containerQuerySelector: '__mock__containerQuerySelector'
+  })
 }));
 
 const DefinePlugin = jest.fn();

--- a/packages/react-cosmos/src/server/__tests__/extend-webpack-config/hmr-plugin-duplicate.js
+++ b/packages/react-cosmos/src/server/__tests__/extend-webpack-config/hmr-plugin-duplicate.js
@@ -1,12 +1,15 @@
 import webpack from 'webpack';
 import extendWebpackConfig from '../../extend-webpack-config';
 
-jest.mock('react-cosmos-config', () => () => ({
-  componentPaths: ['src/components'],
-  fixturePaths: ['test/fixtures'],
-  ignore: [],
-  globalImports: ['./global.css'],
-  hot: true
+jest.mock('react-cosmos-config', () => ({
+  hasCosmosConfig: () => true,
+  getCosmosConfig: () => ({
+    componentPaths: ['src/components'],
+    fixturePaths: ['test/fixtures'],
+    ignore: [],
+    globalImports: ['./global.css'],
+    hot: true
+  })
 }));
 
 const getConfig = () =>

--- a/packages/react-cosmos/src/server/__tests__/extend-webpack-config/hmr-plugin-duplicate.js
+++ b/packages/react-cosmos/src/server/__tests__/extend-webpack-config/hmr-plugin-duplicate.js
@@ -2,7 +2,7 @@ import webpack from 'webpack';
 import extendWebpackConfig from '../../extend-webpack-config';
 
 jest.mock('react-cosmos-config', () => ({
-  hasCosmosConfig: () => true,
+  hasUserCosmosConfig: () => true,
   getCosmosConfig: () => ({
     componentPaths: ['src/components'],
     fixturePaths: ['test/fixtures'],

--- a/packages/react-cosmos/src/server/__tests__/extend-webpack-config/hmr.js
+++ b/packages/react-cosmos/src/server/__tests__/extend-webpack-config/hmr.js
@@ -1,7 +1,7 @@
 import extendWebpackConfig from '../../extend-webpack-config';
 
 jest.mock('react-cosmos-config', () => ({
-  hasCosmosConfig: () => true,
+  hasUserCosmosConfig: () => true,
   getCosmosConfig: () => ({
     componentPaths: ['src/components'],
     fixturePaths: ['test/fixtures'],

--- a/packages/react-cosmos/src/server/__tests__/extend-webpack-config/hmr.js
+++ b/packages/react-cosmos/src/server/__tests__/extend-webpack-config/hmr.js
@@ -1,11 +1,14 @@
 import extendWebpackConfig from '../../extend-webpack-config';
 
-jest.mock('react-cosmos-config', () => () => ({
-  componentPaths: ['src/components'],
-  fixturePaths: ['test/fixtures'],
-  ignore: [],
-  globalImports: ['./global.css'],
-  hot: true
+jest.mock('react-cosmos-config', () => ({
+  hasCosmosConfig: () => true,
+  getCosmosConfig: () => ({
+    componentPaths: ['src/components'],
+    fixturePaths: ['test/fixtures'],
+    ignore: [],
+    globalImports: ['./global.css'],
+    hot: true
+  })
 }));
 
 const DefinePlugin = jest.fn();

--- a/packages/react-cosmos/src/server/__tests__/extend-webpack-config/loaders-webpack1.js
+++ b/packages/react-cosmos/src/server/__tests__/extend-webpack-config/loaders-webpack1.js
@@ -1,7 +1,7 @@
 import extendWebpackConfig from '../../extend-webpack-config';
 
 jest.mock('react-cosmos-config', () => ({
-  hasCosmosConfig: () => true,
+  hasUserCosmosConfig: () => true,
   getCosmosConfig: () => ({
     componentPaths: ['src/components'],
     fixturePaths: ['test/fixtures'],

--- a/packages/react-cosmos/src/server/__tests__/extend-webpack-config/loaders-webpack1.js
+++ b/packages/react-cosmos/src/server/__tests__/extend-webpack-config/loaders-webpack1.js
@@ -1,11 +1,14 @@
 import extendWebpackConfig from '../../extend-webpack-config';
 
-jest.mock('react-cosmos-config', () => () => ({
-  componentPaths: ['src/components'],
-  fixturePaths: ['test/fixtures'],
-  ignore: [],
-  globalImports: ['./global.css'],
-  hot: true
+jest.mock('react-cosmos-config', () => ({
+  hasCosmosConfig: () => true,
+  getCosmosConfig: () => ({
+    componentPaths: ['src/components'],
+    fixturePaths: ['test/fixtures'],
+    ignore: [],
+    globalImports: ['./global.css'],
+    hot: true
+  })
 }));
 
 const DefinePlugin = jest.fn();

--- a/packages/react-cosmos/src/server/__tests__/extend-webpack-config/loaders-webpack2.js
+++ b/packages/react-cosmos/src/server/__tests__/extend-webpack-config/loaders-webpack2.js
@@ -1,7 +1,7 @@
 import extendWebpackConfig from '../../extend-webpack-config';
 
 jest.mock('react-cosmos-config', () => ({
-  hasCosmosConfig: () => true,
+  hasUserCosmosConfig: () => true,
   getCosmosConfig: () => ({
     componentPaths: ['src/components'],
     fixturePaths: ['test/fixtures'],

--- a/packages/react-cosmos/src/server/__tests__/extend-webpack-config/loaders-webpack2.js
+++ b/packages/react-cosmos/src/server/__tests__/extend-webpack-config/loaders-webpack2.js
@@ -1,11 +1,14 @@
 import extendWebpackConfig from '../../extend-webpack-config';
 
-jest.mock('react-cosmos-config', () => () => ({
-  componentPaths: ['src/components'],
-  fixturePaths: ['test/fixtures'],
-  ignore: [],
-  globalImports: ['./global.css'],
-  hot: true
+jest.mock('react-cosmos-config', () => ({
+  hasCosmosConfig: () => true,
+  getCosmosConfig: () => ({
+    componentPaths: ['src/components'],
+    fixturePaths: ['test/fixtures'],
+    ignore: [],
+    globalImports: ['./global.css'],
+    hot: true
+  })
 }));
 
 const DefinePlugin = jest.fn();

--- a/packages/react-cosmos/src/server/__tests__/server/config-generation.js
+++ b/packages/react-cosmos/src/server/__tests__/server/config-generation.js
@@ -1,0 +1,56 @@
+import { hasUserCosmosConfig, generateCosmosConfig } from 'react-cosmos-config';
+import startServer from '../../server';
+
+const mockRootPath = __dirname;
+
+jest.mock('react-cosmos-config', () => ({
+  hasUserCosmosConfig: jest.fn(() => false),
+  generateCosmosConfig: jest.fn(),
+  getCosmosConfig: () => ({
+    rootPath: mockRootPath,
+    port: 9999,
+    hostname: '127.0.0.1',
+    hot: true,
+    globalImports: [],
+    componentPaths: []
+  })
+}));
+
+const getCbs = {};
+const mockGet = jest.fn((path, cb) => {
+  getCbs[path] = cb;
+});
+const mockUse = jest.fn();
+const mockListen = jest.fn();
+
+jest.mock('express', () => {
+  const mockExpress = jest.fn(() => ({
+    get: mockGet,
+    use: mockUse,
+    listen: mockListen
+  }));
+  mockExpress.static = jest.fn();
+  return mockExpress;
+});
+
+jest.mock('webpack', () => jest.fn(() => 'MOCK_WEBPACK_COMPILER'));
+
+jest.mock('webpack-dev-middleware', () => jest.fn(() => 'MOCK_DEV_MIDDLEWARE'));
+jest.mock('webpack-hot-middleware', () => jest.fn(() => 'MOCK_HOT_MIDDLEWARE'));
+
+jest.mock('../../extend-webpack-config', () =>
+  jest.fn(() => 'MOCK_WEBPACK_CONFIG')
+);
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  startServer();
+});
+
+it('checks if user has cosmos config', () => {
+  expect(hasUserCosmosConfig).toHaveBeenCalled();
+});
+
+it('calls config generation function', () => {
+  expect(generateCosmosConfig).toHaveBeenCalled();
+});

--- a/packages/react-cosmos/src/server/__tests__/server/content-base-public-path.js
+++ b/packages/react-cosmos/src/server/__tests__/server/content-base-public-path.js
@@ -3,15 +3,18 @@ import startServer from '../../server';
 
 const mockRootPath = __dirname;
 
-jest.mock('react-cosmos-config', () => () => ({
-  rootPath: mockRootPath,
-  port: 9999,
-  hostname: '127.0.0.1',
-  publicPath: 'server/public',
-  publicUrl: '/static/',
-  webpackConfigPath: require.resolve('./__fsmocks__/webpack.config'),
-  globalImports: [],
-  componentPaths: []
+jest.mock('react-cosmos-config', () => ({
+  hasCosmosConfig: () => true,
+  getCosmosConfig: () => ({
+    rootPath: mockRootPath,
+    port: 9999,
+    hostname: '127.0.0.1',
+    publicPath: 'server/public',
+    publicUrl: '/static/',
+    webpackConfigPath: require.resolve('./__fsmocks__/webpack.config'),
+    globalImports: [],
+    componentPaths: []
+  })
 }));
 
 const getCbs = {};

--- a/packages/react-cosmos/src/server/__tests__/server/content-base-public-path.js
+++ b/packages/react-cosmos/src/server/__tests__/server/content-base-public-path.js
@@ -4,7 +4,7 @@ import startServer from '../../server';
 const mockRootPath = __dirname;
 
 jest.mock('react-cosmos-config', () => ({
-  hasCosmosConfig: () => true,
+  hasUserCosmosConfig: () => true,
   getCosmosConfig: () => ({
     rootPath: mockRootPath,
     port: 9999,

--- a/packages/react-cosmos/src/server/__tests__/server/content-base.js
+++ b/packages/react-cosmos/src/server/__tests__/server/content-base.js
@@ -3,14 +3,17 @@ import startServer from '../../server';
 
 const mockRootPath = __dirname;
 
-jest.mock('react-cosmos-config', () => () => ({
-  rootPath: mockRootPath,
-  port: 9999,
-  hostname: '127.0.0.1',
-  publicUrl: '/static/',
-  webpackConfigPath: require.resolve('./__fsmocks__/webpack.config'),
-  globalImports: [],
-  componentPaths: []
+jest.mock('react-cosmos-config', () => ({
+  hasCosmosConfig: () => true,
+  getCosmosConfig: () => ({
+    rootPath: mockRootPath,
+    port: 9999,
+    hostname: '127.0.0.1',
+    publicUrl: '/static/',
+    webpackConfigPath: require.resolve('./__fsmocks__/webpack.config'),
+    globalImports: [],
+    componentPaths: []
+  })
 }));
 
 const getCbs = {};

--- a/packages/react-cosmos/src/server/__tests__/server/content-base.js
+++ b/packages/react-cosmos/src/server/__tests__/server/content-base.js
@@ -4,7 +4,7 @@ import startServer from '../../server';
 const mockRootPath = __dirname;
 
 jest.mock('react-cosmos-config', () => ({
-  hasCosmosConfig: () => true,
+  hasUserCosmosConfig: () => true,
   getCosmosConfig: () => ({
     rootPath: mockRootPath,
     port: 9999,

--- a/packages/react-cosmos/src/server/__tests__/server/custom-webpack-config.js
+++ b/packages/react-cosmos/src/server/__tests__/server/custom-webpack-config.js
@@ -7,13 +7,16 @@ import extendWebpackConfig from '../../extend-webpack-config';
 const readFileAsync = promisify(fs.readFile);
 const mockRootPath = __dirname;
 
-jest.mock('react-cosmos-config', () => () => ({
-  rootPath: mockRootPath,
-  port: 9999,
-  hostname: '127.0.0.1',
-  webpackConfigPath: require.resolve('./__fsmocks__/webpack.config'),
-  globalImports: [],
-  componentPaths: []
+jest.mock('react-cosmos-config', () => ({
+  hasCosmosConfig: () => true,
+  getCosmosConfig: () => ({
+    rootPath: mockRootPath,
+    port: 9999,
+    hostname: '127.0.0.1',
+    webpackConfigPath: require.resolve('./__fsmocks__/webpack.config'),
+    globalImports: [],
+    componentPaths: []
+  })
 }));
 
 const getCbs = {};

--- a/packages/react-cosmos/src/server/__tests__/server/custom-webpack-config.js
+++ b/packages/react-cosmos/src/server/__tests__/server/custom-webpack-config.js
@@ -8,7 +8,7 @@ const readFileAsync = promisify(fs.readFile);
 const mockRootPath = __dirname;
 
 jest.mock('react-cosmos-config', () => ({
-  hasCosmosConfig: () => true,
+  hasUserCosmosConfig: () => true,
   getCosmosConfig: () => ({
     rootPath: mockRootPath,
     port: 9999,

--- a/packages/react-cosmos/src/server/__tests__/server/default.js
+++ b/packages/react-cosmos/src/server/__tests__/server/default.js
@@ -10,12 +10,15 @@ import extendWebpackConfig from '../../extend-webpack-config';
 const readFileAsync = promisify(fs.readFile);
 const mockRootPath = __dirname;
 
-jest.mock('react-cosmos-config', () => () => ({
-  rootPath: mockRootPath,
-  port: 9999,
-  hostname: '127.0.0.1',
-  globalImports: [],
-  componentPaths: []
+jest.mock('react-cosmos-config', () => ({
+  hasCosmosConfig: () => true,
+  getCosmosConfig: () => ({
+    rootPath: mockRootPath,
+    port: 9999,
+    hostname: '127.0.0.1',
+    globalImports: [],
+    componentPaths: []
+  })
 }));
 
 const getCbs = {};

--- a/packages/react-cosmos/src/server/__tests__/server/default.js
+++ b/packages/react-cosmos/src/server/__tests__/server/default.js
@@ -11,7 +11,7 @@ const readFileAsync = promisify(fs.readFile);
 const mockRootPath = __dirname;
 
 jest.mock('react-cosmos-config', () => ({
-  hasCosmosConfig: () => true,
+  hasUserCosmosConfig: () => true,
   getCosmosConfig: () => ({
     rootPath: mockRootPath,
     port: 9999,

--- a/packages/react-cosmos/src/server/__tests__/server/default.js
+++ b/packages/react-cosmos/src/server/__tests__/server/default.js
@@ -6,12 +6,14 @@ import webpackDevMiddleware from 'webpack-dev-middleware';
 import webpackHotMiddleware from 'webpack-hot-middleware';
 import startServer from '../../server';
 import extendWebpackConfig from '../../extend-webpack-config';
+import { generateCosmosConfig } from 'react-cosmos-config';
 
 const readFileAsync = promisify(fs.readFile);
 const mockRootPath = __dirname;
 
 jest.mock('react-cosmos-config', () => ({
   hasUserCosmosConfig: () => true,
+  generateCosmosConfig: jest.fn(),
   getCosmosConfig: () => ({
     rootPath: mockRootPath,
     port: 9999,
@@ -128,4 +130,8 @@ it('starts express server with hostname & port', () => {
   const [port, hostname] = mockListen.mock.calls[0];
   expect(port).toBe(9999);
   expect(hostname).toBe('127.0.0.1');
+});
+
+it('does not call config generation function', () => {
+  expect(generateCosmosConfig).not.toHaveBeenCalled();
 });

--- a/packages/react-cosmos/src/server/__tests__/server/hot.js
+++ b/packages/react-cosmos/src/server/__tests__/server/hot.js
@@ -3,13 +3,16 @@ import startServer from '../../server';
 
 const mockRootPath = __dirname;
 
-jest.mock('react-cosmos-config', () => () => ({
-  rootPath: mockRootPath,
-  port: 9999,
-  hostname: '127.0.0.1',
-  hot: true,
-  globalImports: [],
-  componentPaths: []
+jest.mock('react-cosmos-config', () => ({
+  hasCosmosConfig: () => true,
+  getCosmosConfig: () => ({
+    rootPath: mockRootPath,
+    port: 9999,
+    hostname: '127.0.0.1',
+    hot: true,
+    globalImports: [],
+    componentPaths: []
+  })
 }));
 
 const getCbs = {};

--- a/packages/react-cosmos/src/server/__tests__/server/hot.js
+++ b/packages/react-cosmos/src/server/__tests__/server/hot.js
@@ -4,7 +4,7 @@ import startServer from '../../server';
 const mockRootPath = __dirname;
 
 jest.mock('react-cosmos-config', () => ({
-  hasCosmosConfig: () => true,
+  hasUserCosmosConfig: () => true,
   getCosmosConfig: () => ({
     rootPath: mockRootPath,
     port: 9999,

--- a/packages/react-cosmos/src/server/__tests__/server/http-proxy.js
+++ b/packages/react-cosmos/src/server/__tests__/server/http-proxy.js
@@ -3,13 +3,16 @@ import httpProxyMiddleware from 'http-proxy-middleware';
 
 const mockRootPath = __dirname;
 
-jest.mock('react-cosmos-config', () => () => ({
-  rootPath: mockRootPath,
-  port: 9999,
-  hostname: '127.0.0.1',
-  httpProxy: { context: '/api', target: 'http://127.0.0.1:4000/api' },
-  globalImports: [],
-  componentPaths: []
+jest.mock('react-cosmos-config', () => ({
+  hasCosmosConfig: () => true,
+  getCosmosConfig: () => ({
+    rootPath: mockRootPath,
+    port: 9999,
+    hostname: '127.0.0.1',
+    httpProxy: { context: '/api', target: 'http://127.0.0.1:4000/api' },
+    globalImports: [],
+    componentPaths: []
+  })
 }));
 
 const getCbs = {};

--- a/packages/react-cosmos/src/server/__tests__/server/http-proxy.js
+++ b/packages/react-cosmos/src/server/__tests__/server/http-proxy.js
@@ -4,7 +4,7 @@ import httpProxyMiddleware from 'http-proxy-middleware';
 const mockRootPath = __dirname;
 
 jest.mock('react-cosmos-config', () => ({
-  hasCosmosConfig: () => true,
+  hasUserCosmosConfig: () => true,
   getCosmosConfig: () => ({
     rootPath: mockRootPath,
     port: 9999,

--- a/packages/react-cosmos/src/server/__tests__/server/missing-webpack-config.js
+++ b/packages/react-cosmos/src/server/__tests__/server/missing-webpack-config.js
@@ -10,7 +10,7 @@ const mockWebpackConfigPath = path.join(
 );
 
 jest.mock('react-cosmos-config', () => ({
-  hasCosmosConfig: () => true,
+  hasUserCosmosConfig: () => true,
   getCosmosConfig: () => ({
     rootPath: mockRootPath,
     port: 9999,

--- a/packages/react-cosmos/src/server/__tests__/server/missing-webpack-config.js
+++ b/packages/react-cosmos/src/server/__tests__/server/missing-webpack-config.js
@@ -9,13 +9,16 @@ const mockWebpackConfigPath = path.join(
   './__fsmocks__/missing.webpack.config'
 );
 
-jest.mock('react-cosmos-config', () => () => ({
-  rootPath: mockRootPath,
-  port: 9999,
-  hostname: '127.0.0.1',
-  webpackConfigPath: mockWebpackConfigPath,
-  globalImports: [],
-  componentPaths: []
+jest.mock('react-cosmos-config', () => ({
+  hasCosmosConfig: () => true,
+  getCosmosConfig: () => ({
+    rootPath: mockRootPath,
+    port: 9999,
+    hostname: '127.0.0.1',
+    webpackConfigPath: mockWebpackConfigPath,
+    globalImports: [],
+    componentPaths: []
+  })
 }));
 
 const getCbs = {};

--- a/packages/react-cosmos/src/server/__tests__/server/public-path.js
+++ b/packages/react-cosmos/src/server/__tests__/server/public-path.js
@@ -3,14 +3,17 @@ import startServer from '../../server';
 
 const mockRootPath = __dirname;
 
-jest.mock('react-cosmos-config', () => () => ({
-  rootPath: mockRootPath,
-  port: 9999,
-  hostname: '127.0.0.1',
-  publicPath: 'server/public',
-  publicUrl: '/static/',
-  globalImports: [],
-  componentPaths: []
+jest.mock('react-cosmos-config', () => ({
+  hasCosmosConfig: () => true,
+  getCosmosConfig: () => ({
+    rootPath: mockRootPath,
+    port: 9999,
+    hostname: '127.0.0.1',
+    publicPath: 'server/public',
+    publicUrl: '/static/',
+    globalImports: [],
+    componentPaths: []
+  })
 }));
 
 const getCbs = {};

--- a/packages/react-cosmos/src/server/__tests__/server/public-path.js
+++ b/packages/react-cosmos/src/server/__tests__/server/public-path.js
@@ -4,7 +4,7 @@ import startServer from '../../server';
 const mockRootPath = __dirname;
 
 jest.mock('react-cosmos-config', () => ({
-  hasCosmosConfig: () => true,
+  hasUserCosmosConfig: () => true,
   getCosmosConfig: () => ({
     rootPath: mockRootPath,
     port: 9999,

--- a/packages/react-cosmos/src/server/embed-modules-webpack-loader.js
+++ b/packages/react-cosmos/src/server/embed-modules-webpack-loader.js
@@ -1,7 +1,7 @@
 // @flow
 
 import path from 'path';
-import getCosmosConfig from 'react-cosmos-config';
+import { getCosmosConfig } from 'react-cosmos-config';
 import { moduleExists } from 'react-cosmos-shared/lib/server';
 import getFilePaths from 'react-cosmos-voyager';
 import { findFixtureFiles } from 'react-cosmos-voyager2/lib/server';

--- a/packages/react-cosmos/src/server/export.js
+++ b/packages/react-cosmos/src/server/export.js
@@ -2,7 +2,7 @@ import path from 'path';
 import fs from 'fs-extra';
 import { silent as silentImport } from 'import-from';
 import extendWebpackConfig from './extend-webpack-config';
-import getCosmosConfig from 'react-cosmos-config';
+import { getCosmosConfig } from 'react-cosmos-config';
 import { getUserWebpackConfig } from './user-webpack-config';
 import getPlaygroundHtml from './playground-html';
 

--- a/packages/react-cosmos/src/server/extend-webpack-config.js
+++ b/packages/react-cosmos/src/server/extend-webpack-config.js
@@ -2,7 +2,7 @@
 
 import path from 'path';
 import omit from 'lodash.omit';
-import getCosmosConfig from 'react-cosmos-config';
+import { getCosmosConfig } from 'react-cosmos-config';
 
 import type { Config } from 'react-cosmos-config/src';
 

--- a/packages/react-cosmos/src/server/print-fixture-files.js
+++ b/packages/react-cosmos/src/server/print-fixture-files.js
@@ -1,4 +1,4 @@
-import getCosmosConfig from 'react-cosmos-config';
+import { getCosmosConfig } from 'react-cosmos-config';
 import { findFixtureFiles } from 'react-cosmos-voyager2/lib/server';
 
 export default async function printFixtureFiles() {

--- a/packages/react-cosmos/src/server/server.js
+++ b/packages/react-cosmos/src/server/server.js
@@ -5,7 +5,11 @@ import httpProxyMiddleware from 'http-proxy-middleware';
 import webpackDevMiddleware from 'webpack-dev-middleware';
 import webpackHotMiddleware from 'webpack-hot-middleware';
 import launchEditor from 'react-dev-utils/launchEditor';
-import { getCosmosConfig } from 'react-cosmos-config';
+import {
+  getCosmosConfig,
+  hasUserCosmosConfig,
+  generateCosmosConfig
+} from 'react-cosmos-config';
 import extendWebpackConfig from './extend-webpack-config';
 import { getUserWebpackConfig } from './user-webpack-config';
 import getPlaygroundHtml from './playground-html';
@@ -18,6 +22,14 @@ const getPublicPath = (cosmosConfig, userWebpackConfig) => {
 };
 
 export default function startServer() {
+  if (!hasUserCosmosConfig()) {
+    const generatedConfigFor = generateCosmosConfig();
+    if (generatedConfigFor) {
+      console.log(`[Cosmos] Nice! You're using ${generatedConfigFor}`);
+      console.log('[Cosmos] Generated a tailored config file for your setup');
+    }
+  }
+
   const cosmosConfig = getCosmosConfig();
   const { rootPath, hostname, hot, port, publicUrl, httpProxy } = cosmosConfig;
 

--- a/packages/react-cosmos/src/server/server.js
+++ b/packages/react-cosmos/src/server/server.js
@@ -5,7 +5,7 @@ import httpProxyMiddleware from 'http-proxy-middleware';
 import webpackDevMiddleware from 'webpack-dev-middleware';
 import webpackHotMiddleware from 'webpack-hot-middleware';
 import launchEditor from 'react-dev-utils/launchEditor';
-import getCosmosConfig from 'react-cosmos-config';
+import { getCosmosConfig } from 'react-cosmos-config';
 import extendWebpackConfig from './extend-webpack-config';
 import { getUserWebpackConfig } from './user-webpack-config';
 import getPlaygroundHtml from './playground-html';

--- a/yarn.lock
+++ b/yarn.lock
@@ -8454,7 +8454,7 @@ right-now@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/right-now/-/right-now-1.0.0.tgz#6e89609deebd7dcdaf8daecc9aea39cf585a0918"
 
-rimraf@2, rimraf@^2.2.8, rimraf@^2.5.1, rimraf@^2.5.4, rimraf@^2.6.1:
+rimraf@2, rimraf@^2.2.8, rimraf@^2.5.1, rimraf@^2.5.4, rimraf@^2.6.1, rimraf@^2.6.2:
   version "2.6.2"
   resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.6.2.tgz#2ed8150d24a16ea8651e6d6ef0f47c4158ce7a36"
   dependencies:


### PR DESCRIPTION
This is the outcome you get as a first time Cosmos user in a Create React App codebase:

> [Cosmos] Nice! You're using Create React App
> [Cosmos] Generated a tailored config file for your setup
> [Cosmos] Using webpack config found at node_modules/react-scripts/config/webpack.config.dev.js
> [Cosmos] Serving static files from public
> [Cosmos] See you at http://localhost:8989/
> webpack built f0feb4958b81e6df42ef in 8260ms

Everything should work as before after config is created or in codebases where no CRA is detected. Config is still not a requirement for Cosmos booting, but CRA would crash without using its own webpack config from the start.