### PR TITLE
Expand example react-boilerplate config

### DIFF
--- a/README.md
+++ b/README.md
@@ -610,7 +610,9 @@ Add `react-cosmos` to dev dependencies and create `cosmos.config.js`.
 ```js
 // cosmos.config.js
 module.exports = {
+  containerQuerySelector: '#app',
   webpackConfigPath: './internals/webpack/webpack.dev.babel',
+  globalImports: ['./app/global-styles.js'],
 };
 ```
 


### PR DESCRIPTION
Add the appropriate containerQuerySelector and a globalImports that imports the default global stylesheet to the react-boilerplate example config.