### PR TITLE
Basic extraction of HOCs from component name

### DIFF
--- a/packages/react-cosmos-playground/src/components/FixtureList/__fixtures__/hoc-names.js
+++ b/packages/react-cosmos-playground/src/components/FixtureList/__fixtures__/hoc-names.js
@@ -8,8 +8,8 @@ export default {
       projectKey: 'test'
     },
     fixtures: {
-      ComponentA: ['fixtureA'],
-      'withRouter(ComponentA)': ['fixtureA'],
+      ThisIsAVeryLongComponentName: ['fixtureA'],
+      'withRouter(ThisIsAVeryLongComponentName)': ['fixtureA'],
       'withRouter(connect(ComponentA))': ['fixtureA']
     },
     urlParams: {},

--- a/packages/react-cosmos-playground/src/components/FixtureList/__fixtures__/hoc-names.js
+++ b/packages/react-cosmos-playground/src/components/FixtureList/__fixtures__/hoc-names.js
@@ -1,0 +1,18 @@
+import FixtureList from '../index';
+
+export default {
+  component: FixtureList,
+
+  props: {
+    options: {
+      projectKey: 'test'
+    },
+    fixtures: {
+      ComponentA: ['fixtureA'],
+      'withRouter(ComponentA)': ['fixtureA'],
+      'withRouter(Connect(ComponentA))': ['fixtureA']
+    },
+    urlParams: {},
+    onUrlChange: () => {}
+  }
+};

--- a/packages/react-cosmos-playground/src/components/FixtureList/__fixtures__/hoc-names.js
+++ b/packages/react-cosmos-playground/src/components/FixtureList/__fixtures__/hoc-names.js
@@ -10,7 +10,7 @@ export default {
     fixtures: {
       ComponentA: ['fixtureA'],
       'withRouter(ComponentA)': ['fixtureA'],
-      'withRouter(Connect(ComponentA))': ['fixtureA']
+      'withRouter(connect(ComponentA))': ['fixtureA']
     },
     urlParams: {},
     onUrlChange: () => {}

--- a/packages/react-cosmos-playground/src/components/FixtureList/__tests__/data-mapper.js
+++ b/packages/react-cosmos-playground/src/components/FixtureList/__tests__/data-mapper.js
@@ -14,12 +14,18 @@ test('transforms fixture data structure to tree data structure', () => {
       type: 'directory',
       expanded: true,
       path: 'dirA',
+      displayData: null,
       children: [
         {
           name: 'Component1',
           type: 'component',
           expanded: true,
           path: 'dirA/Component1',
+          displayData: {
+            componentName: 'Component1',
+            hocs: [],
+            search: 'Component1'
+          },
           children: [
             {
               name: 'fixtureA',
@@ -46,6 +52,7 @@ test('transforms fixture data structure to tree data structure', () => {
       type: 'directory',
       expanded: true,
       path: 'dirB',
+      displayData: null,
       children: [
         // Dirs are placed before components
         {
@@ -53,12 +60,18 @@ test('transforms fixture data structure to tree data structure', () => {
           type: 'directory',
           expanded: true,
           path: 'dirB/subdirA',
+          displayData: null,
           children: [
             {
               name: 'Component4',
               path: 'dirB/subdirA/Component4',
               type: 'component',
               expanded: true,
+              displayData: {
+                componentName: 'Component4',
+                hocs: [],
+                search: 'Component4'
+              },
               children: [
                 {
                   name: 'fixtureA',
@@ -85,6 +98,11 @@ test('transforms fixture data structure to tree data structure', () => {
           type: 'component',
           expanded: true,
           path: 'dirB/Component2',
+          displayData: {
+            componentName: 'Component2',
+            hocs: [],
+            search: 'Component2'
+          },
           children: [
             {
               name: 'fixtureA',
@@ -109,6 +127,11 @@ test('transforms fixture data structure to tree data structure', () => {
           type: 'component',
           expanded: true,
           path: 'dirB/Component3',
+          displayData: {
+            componentName: 'Component3',
+            hocs: [],
+            search: 'Component3'
+          },
           children: [
             {
               name: 'fixtureA',
@@ -153,12 +176,18 @@ test('allows specifying a savedExpansionState object', () => {
       type: 'directory',
       expanded: true,
       path: 'dirA',
+      displayData: null,
       children: [
         {
           name: 'Component1',
           type: 'component',
           expanded: true,
           path: 'dirA/Component1',
+          displayData: {
+            componentName: 'Component1',
+            hocs: [],
+            search: 'Component1'
+          },
           children: [
             {
               name: 'fixtureA',
@@ -185,6 +214,7 @@ test('allows specifying a savedExpansionState object', () => {
       type: 'directory',
       expanded: true,
       path: 'dirB',
+      displayData: null,
       children: [
         // Dirs are placed before components
         {
@@ -192,12 +222,18 @@ test('allows specifying a savedExpansionState object', () => {
           type: 'directory',
           expanded: true,
           path: 'dirB/subdirA',
+          displayData: null,
           children: [
             {
               name: 'Component4',
               path: 'dirB/subdirA/Component4',
               type: 'component',
               expanded: false,
+              displayData: {
+                componentName: 'Component4',
+                hocs: [],
+                search: 'Component4'
+              },
               children: [
                 {
                   name: 'fixtureA',
@@ -224,6 +260,11 @@ test('allows specifying a savedExpansionState object', () => {
           type: 'component',
           expanded: true,
           path: 'dirB/Component2',
+          displayData: {
+            componentName: 'Component2',
+            hocs: [],
+            search: 'Component2'
+          },
           children: [
             {
               name: 'fixtureA',
@@ -248,6 +289,11 @@ test('allows specifying a savedExpansionState object', () => {
           type: 'component',
           expanded: true,
           path: 'dirB/Component3',
+          displayData: {
+            componentName: 'Component3',
+            hocs: [],
+            search: 'Component3'
+          },
           children: [
             {
               name: 'fixtureA',
@@ -295,12 +341,18 @@ test('deals with components with namespaced fixtures', () => {
       type: 'directory',
       expanded: true,
       path: 'dirA',
+      displayData: null,
       children: [
         {
           name: 'Component1',
           type: 'component',
           expanded: true,
           path: 'dirA/Component1',
+          displayData: {
+            componentName: 'Component1',
+            hocs: [],
+            search: 'Component1'
+          },
           children: [
             {
               name: 'fixtureA',
@@ -327,12 +379,18 @@ test('deals with components with namespaced fixtures', () => {
       type: 'directory',
       expanded: true,
       path: 'dirB',
+      displayData: null,
       children: [
         {
           name: 'Component2',
           type: 'component',
           expanded: true,
           path: 'dirB/Component2',
+          displayData: {
+            componentName: 'Component2',
+            hocs: [],
+            search: 'Component2'
+          },
           children: [
             {
               name: 'Some folder',
@@ -380,6 +438,49 @@ test('deals with components with namespaced fixtures', () => {
               urlParams: {
                 component: 'dirB/Component2',
                 fixture: 'fixtureD'
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ];
+
+  expect(fixturesToTreeData(input, savedExpansionState)).toEqual(expected);
+});
+
+test('deals with extracting hoc names', () => {
+  const input = {
+    'dirA/withRouter(Connect(Component1))': ['fixtureA']
+  };
+
+  const savedExpansionState = {};
+
+  const expected = [
+    {
+      name: 'dirA',
+      type: 'directory',
+      expanded: true,
+      path: 'dirA',
+      displayData: null,
+      children: [
+        {
+          name: 'withRouter(Connect(Component1))',
+          type: 'component',
+          expanded: true,
+          path: 'dirA/withRouter(Connect(Component1))',
+          displayData: {
+            componentName: 'Component1',
+            hocs: ['withRouter', 'Connect'],
+            search: 'Component1 withRouter, Connect'
+          },
+          children: [
+            {
+              name: 'fixtureA',
+              type: 'fixture',
+              urlParams: {
+                component: 'dirA/withRouter(Connect(Component1))',
+                fixture: 'fixtureA'
               }
             }
           ]

--- a/packages/react-cosmos-playground/src/components/FixtureList/data-mapper.js
+++ b/packages/react-cosmos-playground/src/components/FixtureList/data-mapper.js
@@ -61,6 +61,28 @@ function parseFixtureArray(componentName, fixtureArray, savedExpansionState) {
   return result;
 }
 
+const extractHocNames = string => {
+  const splitString = string.split('(');
+  let componentName = splitString.pop();
+  const hocs = splitString;
+
+  if (hocs.length > 0) {
+    // Remove trailing )s from componentName
+    componentName = componentName.slice(0, -hocs.length);
+  }
+
+  return { componentName, hocs };
+};
+
+const generateDisplayData = name => {
+  const { componentName, hocs } = extractHocNames(name);
+  return {
+    componentName,
+    hocs,
+    search: `${componentName} ${hocs.join(', ')}`.trim()
+  };
+};
+
 const dataObjectToNestedArray = (base, savedExpansionState, path = '') => {
   const returnChildren = [];
   for (const key in base) {
@@ -77,11 +99,16 @@ const dataObjectToNestedArray = (base, savedExpansionState, path = '') => {
           child.children &&
           (child.type === 'directory' || child.type === 'component')
       );
+      let displayData = null;
+      if (!isDirectory) {
+        displayData = generateDisplayData(key);
+      }
       returnChildren.push({
         name: key,
         path: newPath,
         expanded: getExandedValue(savedExpansionState, newPath),
         type: isDirectory ? 'directory' : 'component',
+        displayData,
         children
         // TODO: Enable this when we'll have component pages
         // https://github.com/react-cosmos/react-cosmos/issues/314

--- a/packages/react-cosmos-playground/src/components/FixtureList/filter.js
+++ b/packages/react-cosmos-playground/src/components/FixtureList/filter.js
@@ -5,7 +5,7 @@ import { match } from 'fuzzaldrin-plus';
 function matcher(filterText, node) {
   const matchText = node.urlParams
     ? `${node.urlParams.component}${node.urlParams.fixture}`
-    : node.name;
+    : node.displayData ? node.displayData.search : node.name;
   return match(matchText, filterText).length > 0;
 }
 

--- a/packages/react-cosmos-playground/src/components/Tree/__fixtures__/scroll-into-view.js
+++ b/packages/react-cosmos-playground/src/components/Tree/__fixtures__/scroll-into-view.js
@@ -21,12 +21,22 @@ export default {
         name: 'ComponentA',
         type: 'component',
         expanded: true,
+        displayData: {
+          componentName: 'ComponentA',
+          hocs: [],
+          search: 'ComponentA'
+        },
         children
       },
       {
         name: 'ComponentB',
         type: 'component',
         expanded: true,
+        displayData: {
+          componentName: 'ComponentB',
+          hocs: [],
+          search: 'ComponentB'
+        },
         children: [
           {
             name: 'baz',

--- a/packages/react-cosmos-playground/src/components/Tree/__fixtures__/tree-with-display-data.js
+++ b/packages/react-cosmos-playground/src/components/Tree/__fixtures__/tree-with-display-data.js
@@ -1,0 +1,39 @@
+import Tree from '../index';
+
+export default {
+  component: Tree,
+
+  props: {
+    nodeArray: [
+      {
+        name: 'withRouter(connect(ComponentA))',
+        path: 'withRouter(connect(ComponentA))',
+        expanded: true,
+        type: 'component',
+        displayData: {
+          componentName: 'ComponentA',
+          hocs: ['withRouter', 'connect'],
+          search: 'ComponentA withRouter, connect'
+        },
+        children: [
+          {
+            type: 'fixture',
+            name: 'fixtureA',
+            urlParams: {
+              component: 'withRouter(connect(ComponentA))',
+              fixture: 'fixtureA'
+            }
+          }
+        ]
+      }
+    ],
+    selected: {
+      component: 'withRouter(connect(ComponentA))',
+      fixture: 'fixtureA'
+    },
+    searchText: '',
+    currentUrlParams: {},
+    onSelect: href => console.log('Selected href: ', href),
+    onToggle: (node, expanded) => console.log('Toggled node: ', node, expanded)
+  }
+};

--- a/packages/react-cosmos-playground/src/components/Tree/__fixtures__/tree-with-editor-and-full-screen-params.js
+++ b/packages/react-cosmos-playground/src/components/Tree/__fixtures__/tree-with-editor-and-full-screen-params.js
@@ -14,6 +14,11 @@ export default {
             name: 'Component1',
             type: 'component',
             expanded: true,
+            displayData: {
+              componentName: 'Component1',
+              hocs: [],
+              search: 'Component1'
+            },
             children: [
               {
                 name: 'fixtureA',
@@ -44,6 +49,11 @@ export default {
             name: 'Component2',
             type: 'component',
             expanded: true,
+            displayData: {
+              componentName: 'Component2',
+              hocs: [],
+              search: 'Component2'
+            },
             children: [
               {
                 name: 'fixtureA',
@@ -67,6 +77,11 @@ export default {
             name: 'Component3',
             type: 'component',
             expanded: false,
+            displayData: {
+              componentName: 'Component3',
+              hocs: [],
+              search: 'Component3'
+            },
             children: [
               {
                 name: 'fixtureA',
@@ -95,6 +110,11 @@ export default {
                 name: 'Component4',
                 type: 'component',
                 expanded: true,
+                displayData: {
+                  componentName: 'Component4',
+                  hocs: [],
+                  search: 'Component4'
+                },
                 children: [
                   {
                     name: 'fixtureA',

--- a/packages/react-cosmos-playground/src/components/Tree/__fixtures__/tree-with-search.js
+++ b/packages/react-cosmos-playground/src/components/Tree/__fixtures__/tree-with-search.js
@@ -14,6 +14,11 @@ export default {
             name: 'Component1',
             type: 'component',
             expanded: true,
+            displayData: {
+              componentName: 'Component1',
+              hocs: [],
+              search: 'Component1'
+            },
             children: [
               {
                 name: 'fixtureA',
@@ -44,6 +49,11 @@ export default {
             name: 'Component2',
             type: 'component',
             expanded: true,
+            displayData: {
+              componentName: 'Component2',
+              hocs: [],
+              search: 'Component2'
+            },
             children: [
               {
                 name: 'fixtureA',
@@ -67,6 +77,11 @@ export default {
             name: 'Component3',
             type: 'component',
             expanded: false,
+            displayData: {
+              componentName: 'Component3',
+              hocs: [],
+              search: 'Component3'
+            },
             children: [
               {
                 name: 'fixtureA',
@@ -95,6 +110,11 @@ export default {
                 name: 'Component4',
                 type: 'component',
                 expanded: true,
+                displayData: {
+                  componentName: 'Component4',
+                  hocs: [],
+                  search: 'Component4'
+                },
                 children: [
                   {
                     name: 'fixtureA',

--- a/packages/react-cosmos-playground/src/components/Tree/__fixtures__/tree.js
+++ b/packages/react-cosmos-playground/src/components/Tree/__fixtures__/tree.js
@@ -14,6 +14,11 @@ export default {
             name: 'Component1',
             type: 'component',
             expanded: true,
+            displayData: {
+              componentName: 'Component1',
+              hocs: [],
+              search: 'Component1'
+            },
             children: [
               {
                 name: 'fixtureA',
@@ -44,6 +49,11 @@ export default {
             name: 'Component2',
             type: 'component',
             expanded: true,
+            displayData: {
+              componentName: 'Component2',
+              hocs: [],
+              search: 'Component2'
+            },
             children: [
               {
                 name: 'fixtureA',
@@ -67,6 +77,11 @@ export default {
             name: 'Component3',
             type: 'component',
             expanded: false,
+            displayData: {
+              componentName: 'Component3',
+              hocs: [],
+              search: 'Component3'
+            },
             children: [
               {
                 name: 'fixtureA',
@@ -95,6 +110,11 @@ export default {
                 name: 'Component4',
                 type: 'component',
                 expanded: true,
+                displayData: {
+                  componentName: 'Component4',
+                  hocs: [],
+                  search: 'Component4'
+                },
                 children: [
                   {
                     name: 'Some folder',

--- a/packages/react-cosmos-playground/src/components/Tree/__tests__/index.js
+++ b/packages/react-cosmos-playground/src/components/Tree/__tests__/index.js
@@ -5,6 +5,7 @@ import { Loader } from 'react-cosmos-loader';
 import treeFixture from '../__fixtures__/tree';
 import treeWithEditorAndFullScreenParams from '../__fixtures__/tree-with-editor-and-full-screen-params';
 import treeWithSearchFixture from '../__fixtures__/tree-with-search';
+import treeWithDisplayData from '../__fixtures__/tree-with-display-data';
 import { FolderIcon, ComponentIcon } from '../../SvgIcon';
 
 describe('Tree', () => {
@@ -154,5 +155,24 @@ describe('Search Highlight', () => {
     expect(highlightB.text()).toContain('b');
     const highlightA = wrapper.find('mark').at(3);
     expect(highlightA.text()).toContain('A');
+  });
+});
+
+describe('Tree with displayData', () => {
+  let wrapper;
+
+  beforeEach(() => {
+    wrapper = mount(<Loader fixture={treeWithDisplayData} />);
+  });
+
+  test('should display the HOCs after the component name', () => {
+    const componentName = wrapper.find('ComponentName').at(0);
+    const name = componentName.find('.name');
+    const hocs = componentName.find('.hocs');
+    expect(name.text()).toContain('ComponentA');
+    expect(name.text()).not.toContain('withRouter');
+    expect(name.text()).not.toContain('connect');
+    expect(hocs.text()).toContain('withRouter, connect');
+    expect(hocs.text()).not.toContain('ComponentA');
   });
 });

--- a/packages/react-cosmos-playground/src/components/Tree/index.js
+++ b/packages/react-cosmos-playground/src/components/Tree/index.js
@@ -75,6 +75,43 @@ const Icon = ({ type }) => {
   }
 };
 
+const extractHocNames = string => {
+  const splitString = string.split('(');
+  const innerString = splitString[splitString.length - 1];
+
+  if (splitString.length > 1) {
+    // Remove trailing )) from innerString
+    const slicedString = innerString.slice(0, -splitString.length + 1);
+    splitString[splitString.length - 1] = slicedString;
+  }
+
+  return {
+    componentName: splitString.pop(),
+    hocs: splitString
+  };
+};
+
+const ComponentName = ({ name, searchText }) => {
+  const { componentName, hocs } = extractHocNames(name);
+  return (
+    <span>
+      <FuzzyHighligher
+        searchText={searchText}
+        textToHighlight={componentName}
+      />
+      {hocs.length > 0 && (
+        <span className={styles.hocs}>
+          {' '}
+          <FuzzyHighligher
+            searchText={searchText}
+            textToHighlight={hocs.join(', ')}
+          />
+        </span>
+      )}
+    </span>
+  );
+};
+
 const TreeFolder = ({
   node,
   onSelect,
@@ -107,7 +144,7 @@ const TreeFolder = ({
           {node.expanded ? <DownArrowIcon /> : <RightArrowIcon />}
         </span>
         <Icon type={node.type} />
-        <FuzzyHighligher searchText={searchText} textToHighlight={node.name} />
+        <ComponentName searchText={searchText} name={node.name} />
       </div>
       <Tree
         nodeArray={node.children}

--- a/packages/react-cosmos-playground/src/components/Tree/index.js
+++ b/packages/react-cosmos-playground/src/components/Tree/index.js
@@ -88,7 +88,12 @@ const extractHocNames = string => {
   return { componentName, hocs };
 };
 
-const ComponentName = ({ name, searchText }) => {
+const ComponentName = ({ node: { name, type }, searchText }) => {
+  if (type !== 'component') {
+    // Don't parse e.g. directory names for parentheses
+    return <FuzzyHighligher searchText={searchText} textToHighlight={name} />;
+  }
+
   const { componentName, hocs } = extractHocNames(name);
   return (
     <span>
@@ -141,7 +146,7 @@ const TreeFolder = ({
           {node.expanded ? <DownArrowIcon /> : <RightArrowIcon />}
         </span>
         <Icon type={node.type} />
-        <ComponentName searchText={searchText} name={node.name} />
+        <ComponentName searchText={searchText} node={node} />
       </div>
       <Tree
         nodeArray={node.children}

--- a/packages/react-cosmos-playground/src/components/Tree/index.js
+++ b/packages/react-cosmos-playground/src/components/Tree/index.js
@@ -75,26 +75,13 @@ const Icon = ({ type }) => {
   }
 };
 
-const extractHocNames = string => {
-  const splitString = string.split('(');
-  let componentName = splitString.pop();
-  const hocs = splitString;
-
-  if (hocs.length > 0) {
-    // Remove trailing )s from componentName
-    componentName = componentName.slice(0, -hocs.length);
-  }
-
-  return { componentName, hocs };
-};
-
-const ComponentName = ({ node: { name, type }, searchText }) => {
+const ComponentName = ({ node: { name, type, displayData }, searchText }) => {
   if (type !== 'component') {
-    // Don't parse e.g. directory names for parentheses
+    // Don't deal with stuff like hoc names for e.g. directories
     return <FuzzyHighligher searchText={searchText} textToHighlight={name} />;
   }
 
-  const { componentName, hocs } = extractHocNames(name);
+  const { componentName, hocs } = displayData;
 
   const componentClasses = classNames({
     [styles.truncate]: true,
@@ -303,6 +290,12 @@ const nodeShape = shape({
   type: oneOf(['directory', 'component', 'fixture']).isRequired,
   expanded: bool,
   isHidden: bool,
+  path: string,
+  displayData: shape({
+    componentName: string.isRequired,
+    hocs: arrayOf(string).isRequired,
+    search: string.isRequired
+  }),
   urlParams: shape({
     component: string.isRequired,
     fixture: string.isRequired

--- a/packages/react-cosmos-playground/src/components/Tree/index.js
+++ b/packages/react-cosmos-playground/src/components/Tree/index.js
@@ -77,18 +77,15 @@ const Icon = ({ type }) => {
 
 const extractHocNames = string => {
   const splitString = string.split('(');
-  const innerString = splitString[splitString.length - 1];
+  let componentName = splitString.pop();
+  const hocs = splitString;
 
-  if (splitString.length > 1) {
-    // Remove trailing )) from innerString
-    const slicedString = innerString.slice(0, -splitString.length + 1);
-    splitString[splitString.length - 1] = slicedString;
+  if (hocs.length > 0) {
+    // Remove trailing )s from componentName
+    componentName = componentName.slice(0, -hocs.length);
   }
 
-  return {
-    componentName: splitString.pop(),
-    hocs: splitString
-  };
+  return { componentName, hocs };
 };
 
 const ComponentName = ({ name, searchText }) => {

--- a/packages/react-cosmos-playground/src/components/Tree/index.js
+++ b/packages/react-cosmos-playground/src/components/Tree/index.js
@@ -95,12 +95,21 @@ const ComponentName = ({ node: { name, type }, searchText }) => {
   }
 
   const { componentName, hocs } = extractHocNames(name);
+
+  const componentClasses = classNames({
+    [styles.truncate]: true,
+    [styles.truncateHoc]: hocs.length > 0,
+    [styles.truncateComponent]: hocs.length === 0
+  });
+
   return (
-    <span>
-      <FuzzyHighligher
-        searchText={searchText}
-        textToHighlight={componentName}
-      />
+    <span className={componentClasses}>
+      <span className={styles.name}>
+        <FuzzyHighligher
+          searchText={searchText}
+          textToHighlight={componentName}
+        />
+      </span>
       {hocs.length > 0 && (
         <span className={styles.hocs}>
           {' '}

--- a/packages/react-cosmos-playground/src/components/Tree/index.less
+++ b/packages/react-cosmos-playground/src/components/Tree/index.less
@@ -46,7 +46,7 @@
   }
 
   .hocs {
-    color: gray;
+    color: @left-nav-color-selected-lighter;
     font-size: 80%;
   }
 }

--- a/packages/react-cosmos-playground/src/components/Tree/index.less
+++ b/packages/react-cosmos-playground/src/components/Tree/index.less
@@ -35,19 +35,31 @@
     margin-right: 0.5 * @default-spacing;
   }
 
-  span {
+  .truncate {
     white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis;
   }
-
-  &:hover {
-    background: @left-nav-bgcolor-selected;
+  // Needed to make sure styling of the ellipsis is the right color
+  // depending on whether or not we are showing HOC names.
+  .truncateHoc {
+    color: @left-nav-color-selected-lighter;
+  }
+  .truncateComponent {
+    color: @left-nav-color-selected;
   }
 
   .hocs {
     color: @left-nav-color-selected-lighter;
     font-size: 80%;
+  }
+
+  .name {
+    color: @left-nav-color-selected;
+  }
+
+  &:hover {
+    background: @left-nav-bgcolor-selected;
   }
 }
 

--- a/packages/react-cosmos-playground/src/components/Tree/index.less
+++ b/packages/react-cosmos-playground/src/components/Tree/index.less
@@ -44,6 +44,11 @@
   &:hover {
     background: @left-nav-bgcolor-selected;
   }
+
+  .hocs {
+    color: gray;
+    font-size: 80%;
+  }
 }
 
 .fixtureDirectory {

--- a/packages/react-cosmos-playground/src/utils/common.less
+++ b/packages/react-cosmos-playground/src/utils/common.less
@@ -1,13 +1,18 @@
 @default-spacing: 10px;
-@default-font-family: 'BlinkMacSystemFont', 'Lucida Grande', 'Segoe UI', Ubuntu,
-  Cantarell, sans-serif;
+@default-font-family: 'BlinkMacSystemFont',
+  'Lucida Grande',
+  'Segoe UI',
+  Ubuntu,
+  Cantarell,
+  sans-serif;
 @default-font-size: 14px;
 
 @left-nav-bgcolor: #0c293e;
 @left-nav-bgcolor-darker: rgb(10, 33, 50);
 @left-nav-bgcolor-selected: rgba(255, 255, 255, 0.1);
 @left-nav-color: #a5bed2;
-@left-nav-color-selected: #f8fafc;
+@left-nav-color-selected: rgb(248,250,252);
+@left-nav-color-selected-lighter: rgba(248, 250, 252, 0.6);
 
 @drag-handle-size: 4px;
 @editor-font-size: 14px;


### PR DESCRIPTION
Given:
```
fixtures: {
  ComponentA: ['fixtureA'],
  'withRouter(ComponentA)': ['fixtureA'],
  'withRouter(Connect(ComponentA))': ['fixtureA']
}
```
(Note: I realise it should be `connect` rather than `Connect`, apologies).

Instead of:

<img width="306" alt="screen shot 2017-11-18 at 3 20 54 pm" src="https://user-images.githubusercontent.com/4144910/32978008-1db8d0e8-cc74-11e7-97c4-02ebc8689871.png">

We show:

<img width="262" alt="screen shot 2017-11-18 at 3 19 29 pm" src="https://user-images.githubusercontent.com/4144910/32978000-e833907a-cc73-11e7-9f71-d7d96c1f6d83.png">


Please let me know thoughts on styling. I personally prefer to always have the HOC names shown, rather than a tooltip, as they are an integral part of the component I have created a fixture for.

This is just a simple PR, if one wanted to do something intelligent with e.g matching HOC names to proxies (or automatically showing a helpful error message 'we notice your component relies on redux but you don't have the redux proxy installed') then that can come at a later stage.

There's an outstanding issue with search; if you search for "comp with", you'll get no matches as the actual text we are searching is "withRouter(ComponentA)" [the ordering is different]. Not hard to fix but wanted to get approval for the PR before polishing.

Also note if the user has an opening parentheses in their actual component name, then there's not much we can do about that, it'll get parsed.