### PR TITLE
Fix Context Proxy example in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -297,9 +297,11 @@ export default [
 // __fixtures__/example.js
 export default {
   component: MyComponent,
-  theme: {
-    backgroundColor: '#f1f1f1',
-    color: '#222'
+  context: {
+    theme: {
+      backgroundColor: '#f1f1f1',
+      color: '#222'
+    }
   }
 }
 ```


### PR DESCRIPTION
Hello,

I beleive the context items should be under the `context` key.

P.S.: Great job with v3.0 👍 