### PR TITLE
Avoid re-starting Cosmos when adding new component / fixtures files

### DIFF
--- a/packages/react-cosmos/package.json
+++ b/packages/react-cosmos/package.json
@@ -12,6 +12,7 @@
     "lib"
   ],
   "dependencies": {
+    "commondir": "^1.0.1",
     "express": "^4.15.4",
     "fs-extra": "^4.0.1",
     "glob": "^7.1.1",

--- a/packages/react-cosmos/src/server/__tests__/embed-modules-webpack-loader/new-fixtures.js
+++ b/packages/react-cosmos/src/server/__tests__/embed-modules-webpack-loader/new-fixtures.js
@@ -20,28 +20,28 @@ jest.mock('react-cosmos-config', () => ({
 
 const mockFixtureFiles = [
   {
-    filePath: 'components/__fixtures__/Foo/blank.js',
+    filePath: '/components/__fixtures__/Foo/blank.js',
     components: [
       {
-        filePath: 'components/Foo.js',
+        filePath: '/components/Foo.js',
         name: 'Foo'
       }
     ]
   },
   {
-    filePath: 'components/__fixtures__/Bar/one.js',
+    filePath: '/components/__fixtures__/Bar/one.js',
     components: [
       {
-        filePath: 'components/Bar.js',
+        filePath: '/components/Bar.js',
         name: 'Bar'
       }
     ]
   },
   {
-    filePath: 'components/__fixtures__/Bar/two.json',
+    filePath: '/components/__fixtures__/Bar/two.json',
     components: [
       {
-        filePath: 'components/Bar.js',
+        filePath: '/components/Bar.js',
         name: 'Bar'
       }
     ]
@@ -94,9 +94,9 @@ it('injects fixture modules', () => {
   const [, fixtureModules] = output.match(/fixtureModules: (.+)(,|$)/);
 
   const expected = `{
-    'components/__fixtures__/Foo/blank.js':require('components/__fixtures__/Foo/blank.js'),
-    'components/__fixtures__/Bar/one.js':require('components/__fixtures__/Bar/one.js'),
-    'components/__fixtures__/Bar/two.json':require('components/__fixtures__/Bar/two.json')
+    '/components/__fixtures__/Foo/blank.js':require('/components/__fixtures__/Foo/blank.js'),
+    '/components/__fixtures__/Bar/one.js':require('/components/__fixtures__/Bar/one.js'),
+    '/components/__fixtures__/Bar/two.json':require('/components/__fixtures__/Bar/two.json')
   }`;
   expect(fixtureModules).toEqual(expected.replace(/\s/g, ''));
 });
@@ -121,16 +121,12 @@ it('injects contexts', () => {
   const output = loaderCallback.mock.calls[0][1];
   const [, contexts] = output.match(/contexts: (.+)(,|$)/);
 
-  const expected = `[
-    require.context('components/__fixtures__/Foo',false,/\\.jsx?$/),
-    require.context('components/__fixtures__/Bar',false,/\\.jsx?$/)
-  ]`;
+  const expected = `require.context('/components',true,/\\.(j|t)sx?$/)`;
   expect(contexts).toEqual(expected.replace(/\s/g, ''));
 });
 
 it('registers user dirs as loader deps', () => {
-  expect(mockAddDependency).toHaveBeenCalledWith('components/__fixtures__/Foo');
-  expect(mockAddDependency).toHaveBeenCalledWith('components/__fixtures__/Bar');
+  expect(mockAddDependency).toHaveBeenCalledWith('/components');
 });
 
 it('injects empty deprecated components', () => {

--- a/packages/react-cosmos/src/server/__tests__/embed-modules-webpack-loader/old-fixtures.js
+++ b/packages/react-cosmos/src/server/__tests__/embed-modules-webpack-loader/old-fixtures.js
@@ -11,16 +11,16 @@ jest.mock('react-cosmos-config', () => ({
 
 jest.mock('react-cosmos-voyager', () => () => ({
   components: {
-    Foo: 'components/Foo.js',
-    Bar: 'components/Bar.js'
+    Foo: '/components/Foo.js',
+    Bar: '/components/Bar.js'
   },
   fixtures: {
     Foo: {
-      blank: 'components/__fixtures__/Foo/blank.js'
+      blank: '/components/__fixtures__/Foo/blank.js'
     },
     Bar: {
-      one: 'components/__fixtures__/Bar/one.js',
-      two: 'components/__fixtures__/Bar/two.json'
+      one: '/components/__fixtures__/Bar/one.js',
+      two: '/components/__fixtures__/Bar/two.json'
     }
   }
 }));
@@ -55,9 +55,9 @@ it('injects fixture modules', () => {
   const [, fixtureModules] = output.match(/fixtureModules: (.+)(,|$)/);
 
   const expected = `{
-    'components/__fixtures__/Foo/blank.js':require('components/__fixtures__/Foo/blank.js'),
-    'components/__fixtures__/Bar/one.js':require('components/__fixtures__/Bar/one.js'),
-    'components/__fixtures__/Bar/two.json':require('components/__fixtures__/Bar/two.json')
+    '/components/__fixtures__/Foo/blank.js':require('/components/__fixtures__/Foo/blank.js'),
+    '/components/__fixtures__/Bar/one.js':require('/components/__fixtures__/Bar/one.js'),
+    '/components/__fixtures__/Bar/two.json':require('/components/__fixtures__/Bar/two.json')
   }`;
   expect(fixtureModules).toEqual(expected.replace(/\s/g, ''));
 });
@@ -68,28 +68,28 @@ it('injects fixture files', () => {
 
   expect(JSON.parse(fixtureFiles)).toEqual([
     {
-      filePath: 'components/__fixtures__/Foo/blank.js',
+      filePath: '/components/__fixtures__/Foo/blank.js',
       components: [
         {
-          filePath: 'components/Foo.js',
+          filePath: '/components/Foo.js',
           name: 'Foo'
         }
       ]
     },
     {
-      filePath: 'components/__fixtures__/Bar/one.js',
+      filePath: '/components/__fixtures__/Bar/one.js',
       components: [
         {
-          filePath: 'components/Bar.js',
+          filePath: '/components/Bar.js',
           name: 'Bar'
         }
       ]
     },
     {
-      filePath: 'components/__fixtures__/Bar/two.json',
+      filePath: '/components/__fixtures__/Bar/two.json',
       components: [
         {
-          filePath: 'components/Bar.js',
+          filePath: '/components/Bar.js',
           name: 'Bar'
         }
       ]
@@ -110,16 +110,12 @@ it('injects contexts', () => {
   const output = loaderCallback.mock.calls[0][1];
   const [, contexts] = output.match(/contexts: (.+)(,|$)/);
 
-  const expected = `[
-    require.context('components/__fixtures__/Foo',false,/\\.jsx?$/),
-    require.context('components/__fixtures__/Bar',false,/\\.jsx?$/)
-  ]`;
+  const expected = `require.context('/components',true,/\\.(j|t)sx?$/)`;
   expect(contexts).toEqual(expected.replace(/\s/g, ''));
 });
 
 it('registers user dirs as loader deps', () => {
-  expect(mockAddDependency).toHaveBeenCalledWith('components/__fixtures__/Foo');
-  expect(mockAddDependency).toHaveBeenCalledWith('components/__fixtures__/Bar');
+  expect(mockAddDependency).toHaveBeenCalledWith('/components');
 });
 
 it('injects deprecated components', () => {
@@ -129,8 +125,8 @@ it('injects deprecated components', () => {
   );
 
   const expected = `{
-    'components/Foo.js':require('components/Foo.js'),
-    'components/Bar.js':require('components/Bar.js')
+    '/components/Foo.js':require('/components/Foo.js'),
+    '/components/Bar.js':require('/components/Bar.js')
   }`;
   expect(deprecatedComponentModules).toEqual(expected.replace(/\s/g, ''));
 });

--- a/packages/react-cosmos/src/server/embed-modules-webpack-loader.js
+++ b/packages/react-cosmos/src/server/embed-modules-webpack-loader.js
@@ -1,6 +1,6 @@
 // @flow
 
-import path from 'path';
+import commondir from 'commondir';
 import { getCosmosConfig } from 'react-cosmos-config';
 import { moduleExists } from 'react-cosmos-shared/lib/server';
 import getFilePaths from 'react-cosmos-voyager';
@@ -32,14 +32,11 @@ module.exports = async function embedModules(source: string) {
   const componentModuleCallls = convertPathsToRequireCalls(
     keys(deprecatedComponentModules).map(c => deprecatedComponentModules[c])
   );
+  const { componentsCommonDir, contextCall } = getContextCall(fixtureFiles);
 
-  const contexts = getUniqueDirsOfPaths(fixturePaths);
-  contexts.forEach(dirPath => {
-    // This ensures this loader is invalidated whenever a new component/fixture
-    // file is created or renamed, which leads succesfully uda ...
-    this.addDependency(dirPath);
-  });
-  const contextCalls = convertDirPathsToContextCalls(contexts);
+  // This ensures this loader is invalidated whenever a new component/fixture
+  // file is created or renamed, which leads succesfully uda ...
+  this.addDependency(componentsCommonDir);
 
   const result = source
     .replace(/FIXTURE_MODULES/g, fixtureModuleCalls)
@@ -49,7 +46,7 @@ module.exports = async function embedModules(source: string) {
       /PROXIES/g,
       moduleExists(proxiesPath) ? convertPathToRequireCall(proxiesPath) : '[]'
     )
-    .replace(/CONTEXTS/g, contextCalls);
+    .replace(/CONTEXTS/g, contextCall);
 
   callback(null, result);
 };
@@ -106,15 +103,17 @@ function convertPathToRequireCall(p) {
   return `require('${p}')`;
 }
 
-function getUniqueDirsOfPaths(paths) {
-  const dirs = new Set();
-  paths.forEach(p => dirs.add(path.dirname(p)));
+function getContextCall(fixtureFiles) {
+  const paths = fixtureFiles
+    .map(file => file.components.map(component => component.filePath))
+    .reduce((list, current) => [...list, ...current]);
 
-  return [...dirs];
-}
+  const componentsCommonDir = commondir(paths);
 
-function convertDirPathsToContextCalls(dirPaths) {
-  return `[${dirPaths
-    .map(dirPath => `require.context('${dirPath}',false,/\\.jsx?$/)`)
-    .join(',')}]`;
+  return {
+    contextCall: `require.context('${
+      componentsCommonDir
+    }',true,/\\.(j|t)sx?$/)`,
+    componentsCommonDir
+  };
 }


### PR DESCRIPTION
While @skidding was walking me through the Cosmos booting process, we realized that finding the common directory for fixtures and components could be done to avoid re-starting Cosmos when you create a new component or fixtures file.

This PR solves this problem by watching the common directory of fixtures and component:

```
/components/__fixtures__/Foo/blank.js
/components/__fixtures__/Bar/one.js
/components/Foo.js
/components/Bar.js

-> common directory to watch for changes: /components
```

See [screencast](https://d3vv6lp55qjaqc.cloudfront.net/items/1D2m0b2C2a1S3i0O2O30/Screen%20Recording%202017-11-23%20at%2002.59%20PM.gif?X-CloudApp-Visitor-Id=2680119&v=7507541a)