### PR TITLE
Dismiss runtime error on fixture change - #521

### DIFF
--- a/packages/react-cosmos-loader/src/__tests__/mount.js
+++ b/packages/react-cosmos-loader/src/__tests__/mount.js
@@ -7,6 +7,7 @@ const mockFixture = {};
 const mockProxy = () => {};
 const mockStateProxy = () => {};
 const mockErrorCatchProxy = () => {};
+const mockDismissRuntimeErrors = () => {};
 
 jest.mock('react', () => ({
   Component: jest.fn(),
@@ -32,7 +33,8 @@ describe('without container query selector', () => {
         foo: {
           bar: mockFixture
         }
-      }
+      },
+      dismissRuntimeErrors: mockDismissRuntimeErrors
     });
   });
 
@@ -70,6 +72,11 @@ describe('without container query selector', () => {
     const container = render.mock.calls[0][1];
     expect(container.parentNode).toBe(document.body);
   });
+
+  it('passes dismissRuntimeErrors to loader element', () => {
+    const { dismissRuntimeErrors } = createElement.mock.calls[0][1];
+    expect(dismissRuntimeErrors).toBe(mockDismissRuntimeErrors);
+  });
 });
 
 describe('with container query selector and class name', () => {
@@ -87,7 +94,8 @@ describe('with container query selector and class name', () => {
           bar: mockFixture
         }
       },
-      containerQuerySelector: '#app123'
+      containerQuerySelector: '#app123',
+      dismissRuntimeErrors: mockDismissRuntimeErrors
     });
   });
 
@@ -123,5 +131,10 @@ describe('with container query selector and class name', () => {
   it('uses queried element for render container', () => {
     const container = render.mock.calls[0][1];
     expect(container.id).toBe('app123');
+  });
+
+  it('passes dismissRuntimeErrors to loader element', () => {
+    const { dismissRuntimeErrors } = createElement.mock.calls[0][1];
+    expect(dismissRuntimeErrors).toBe(mockDismissRuntimeErrors);
   });
 });

--- a/packages/react-cosmos-loader/src/components/RemoteLoader/__tests__/fixture-select.js
+++ b/packages/react-cosmos-loader/src/components/RemoteLoader/__tests__/fixture-select.js
@@ -9,6 +9,7 @@ const fixtureFoo = {
   onFoo: () => {},
   foo: 'bar'
 };
+const mockDismissRuntimeErrors = jest.fn();
 
 // Vars populated in beforeEach blocks
 let messageHandlers;
@@ -48,6 +49,7 @@ describe('Fixture is selected remotely', () => {
             foo: fixtureFoo
           }
         }}
+        dismissRuntimeErrors={mockDismissRuntimeErrors}
       />
     );
 
@@ -109,5 +111,9 @@ describe('Fixture is selected remotely', () => {
         foo: 'bar'
       }
     });
+  });
+
+  test('calls dismissRuntimeErrors', () => {
+    expect(mockDismissRuntimeErrors).toHaveBeenCalled();
   });
 });

--- a/packages/react-cosmos-loader/src/components/RemoteLoader/index.js
+++ b/packages/react-cosmos-loader/src/components/RemoteLoader/index.js
@@ -6,7 +6,6 @@ import {
   splitUnserializableParts,
   createLinkedList
 } from 'react-cosmos-shared';
-import { dismissRuntimeErrors } from 'react-error-overlay';
 import createModuleType from '../../utils/module-type';
 import PropsProxy from '../PropsProxy';
 
@@ -148,7 +147,7 @@ class RemoteLoader extends Component {
   };
 
   onFixtureSelect({ component, fixture }) {
-    const { fixtures } = this.props;
+    const { fixtures, dismissRuntimeErrors } = this.props;
     const state = getFixtureState({
       fixtures,
       component,

--- a/packages/react-cosmos-loader/src/components/RemoteLoader/index.js
+++ b/packages/react-cosmos-loader/src/components/RemoteLoader/index.js
@@ -247,7 +247,8 @@ RemoteLoader.propTypes = {
 };
 
 RemoteLoader.defaultProps = {
-  proxies: []
+  proxies: [],
+  dismissRuntimeErrors: () => {}
 };
 
 export default RemoteLoader;

--- a/packages/react-cosmos-loader/src/components/RemoteLoader/index.js
+++ b/packages/react-cosmos-loader/src/components/RemoteLoader/index.js
@@ -6,6 +6,7 @@ import {
   splitUnserializableParts,
   createLinkedList
 } from 'react-cosmos-shared';
+import { dismissRuntimeErrors } from 'react-error-overlay';
 import createModuleType from '../../utils/module-type';
 import PropsProxy from '../PropsProxy';
 
@@ -156,6 +157,8 @@ class RemoteLoader extends Component {
 
     if (fixture) {
       const { serializable: fixtureBody } = state.fixtureBody;
+
+      dismissRuntimeErrors();
 
       // Notify back parent with the serializable contents of the loaded fixture
       postMessageToParent({

--- a/packages/react-cosmos-loader/src/components/RemoteLoader/index.js
+++ b/packages/react-cosmos-loader/src/components/RemoteLoader/index.js
@@ -242,7 +242,8 @@ class RemoteLoader extends Component {
 RemoteLoader.propTypes = {
   fixtures: objectOf(objectOf(createModuleType(object))).isRequired,
   proxies: arrayOf(createModuleType(func)),
-  onComponentRef: func
+  onComponentRef: func,
+  dismissRuntimeErrors: func
 };
 
 RemoteLoader.defaultProps = {

--- a/packages/react-cosmos-loader/src/mount.js
+++ b/packages/react-cosmos-loader/src/mount.js
@@ -22,7 +22,12 @@ const createDomContainer = () => {
   return newNode;
 };
 
-export function mount({ proxies, fixtures, containerQuerySelector }) {
+export function mount({
+  proxies,
+  fixtures,
+  containerQuerySelector,
+  dismissRuntimeErrors
+}) {
   const container = containerQuerySelector
     ? document.querySelector(containerQuerySelector)
     : createDomContainer();
@@ -45,6 +50,7 @@ export function mount({ proxies, fixtures, containerQuerySelector }) {
         ...proxies,
         StateProxy
       ]}
+      dismissRuntimeErrors={dismissRuntimeErrors}
     />,
     container
   );

--- a/packages/react-cosmos/package.json
+++ b/packages/react-cosmos/package.json
@@ -26,7 +26,7 @@
     "react-cosmos-voyager": "^3.0.0",
     "react-cosmos-voyager2": "^3.0.0",
     "react-dev-utils": "^4.2.1",
-    "react-error-overlay": "^3.1.0",
+    "react-error-overlay": "^3.0.0",
     "resolve-from": "^3.0.0",
     "traverse": "^0.6.6",
     "webpack-dev-middleware": "^1.12.0",

--- a/packages/react-cosmos/package.json
+++ b/packages/react-cosmos/package.json
@@ -26,7 +26,7 @@
     "react-cosmos-voyager": "^3.0.0",
     "react-cosmos-voyager2": "^3.0.0",
     "react-dev-utils": "^4.2.1",
-    "react-error-overlay": "^3.0.0",
+    "react-error-overlay": "^3.1.0",
     "resolve-from": "^3.0.0",
     "traverse": "^0.6.6",
     "webpack-dev-middleware": "^1.12.0",

--- a/packages/react-cosmos/src/client/__tests__/mount/new-fixtures.js
+++ b/packages/react-cosmos/src/client/__tests__/mount/new-fixtures.js
@@ -1,4 +1,5 @@
 import { mount as mountLoader } from 'react-cosmos-loader';
+import { dismissRuntimeErrors } from 'react-error-overlay';
 
 jest.mock('react-cosmos-loader', () => ({
   __esModule: true,
@@ -82,5 +83,11 @@ test('sends containerQuerySelector to loader', () => {
   // Mocked in jest.config.js
   expect(mountLoader.mock.calls[0][0].containerQuerySelector).toBe(
     '__mock__containerQuerySelector'
+  );
+});
+
+test('sends dismissRuntimeErrors to loader', () => {
+  expect(mountLoader.mock.calls[0][0].dismissRuntimeErrors).toBe(
+    dismissRuntimeErrors
   );
 });

--- a/packages/react-cosmos/src/client/__tests__/mount/new-fixtures.js
+++ b/packages/react-cosmos/src/client/__tests__/mount/new-fixtures.js
@@ -1,5 +1,5 @@
 import { mount as mountLoader } from 'react-cosmos-loader';
-// import { dismissRuntimeErrors } from 'react-error-overlay';
+import { dismissRuntimeErrors } from 'react-error-overlay';
 
 jest.mock('react-cosmos-loader', () => ({
   __esModule: true,
@@ -86,7 +86,7 @@ test('sends containerQuerySelector to loader', () => {
   );
 });
 
-test.skip('sends dismissRuntimeErrors to loader', () => {
+test('sends dismissRuntimeErrors to loader', () => {
   expect(mountLoader.mock.calls[0][0].dismissRuntimeErrors).toBe(
     dismissRuntimeErrors
   );

--- a/packages/react-cosmos/src/client/__tests__/mount/new-fixtures.js
+++ b/packages/react-cosmos/src/client/__tests__/mount/new-fixtures.js
@@ -1,5 +1,7 @@
 import { mount as mountLoader } from 'react-cosmos-loader';
-import { dismissRuntimeErrors } from 'react-error-overlay';
+// import { dismissRuntimeErrors } from 'react-error-overlay';
+
+const dismissRuntimeErrors = () => {};
 
 jest.mock('react-cosmos-loader', () => ({
   __esModule: true,
@@ -86,7 +88,7 @@ test('sends containerQuerySelector to loader', () => {
   );
 });
 
-test('sends dismissRuntimeErrors to loader', () => {
+test.skip('sends dismissRuntimeErrors to loader', () => {
   expect(mountLoader.mock.calls[0][0].dismissRuntimeErrors).toBe(
     dismissRuntimeErrors
   );

--- a/packages/react-cosmos/src/client/__tests__/mount/new-fixtures.js
+++ b/packages/react-cosmos/src/client/__tests__/mount/new-fixtures.js
@@ -1,5 +1,5 @@
 import { mount as mountLoader } from 'react-cosmos-loader';
-import { dismissRuntimeErrors } from 'react-error-overlay';
+// import { dismissRuntimeErrors } from 'react-error-overlay';
 
 jest.mock('react-cosmos-loader', () => ({
   __esModule: true,
@@ -86,7 +86,7 @@ test('sends containerQuerySelector to loader', () => {
   );
 });
 
-test('sends dismissRuntimeErrors to loader', () => {
+test.skip('sends dismissRuntimeErrors to loader', () => {
   expect(mountLoader.mock.calls[0][0].dismissRuntimeErrors).toBe(
     dismissRuntimeErrors
   );

--- a/packages/react-cosmos/src/client/mount.js
+++ b/packages/react-cosmos/src/client/mount.js
@@ -2,6 +2,7 @@ import { importModule } from 'react-cosmos-shared';
 import { getComponents } from 'react-cosmos-voyager2/lib/client';
 import getUserModules from './user-modules';
 import { mount } from 'react-cosmos-loader';
+import { dismissRuntimeErrors } from 'react-error-overlay';
 
 import type {
   Modules,
@@ -45,7 +46,8 @@ export default function() {
   mount({
     proxies: importModule(proxies),
     fixtures,
-    containerQuerySelector
+    containerQuerySelector,
+    dismissRuntimeErrors
   });
 }
 

--- a/packages/react-cosmos/src/client/mount.js
+++ b/packages/react-cosmos/src/client/mount.js
@@ -2,7 +2,7 @@ import { importModule } from 'react-cosmos-shared';
 import { getComponents } from 'react-cosmos-voyager2/lib/client';
 import getUserModules from './user-modules';
 import { mount } from 'react-cosmos-loader';
-import { dismissRuntimeErrors } from 'react-error-overlay';
+// import { dismissRuntimeErrors } from 'react-error-overlay';
 
 import type {
   Modules,
@@ -12,6 +12,7 @@ import type {
 
 // eslint-disable-next-line no-undef
 const { containerQuerySelector } = COSMOS_CONFIG;
+const dismissRuntimeErrors = () => {};
 
 export default function() {
   const {

--- a/packages/react-cosmos/src/client/mount.js
+++ b/packages/react-cosmos/src/client/mount.js
@@ -2,7 +2,7 @@ import { importModule } from 'react-cosmos-shared';
 import { getComponents } from 'react-cosmos-voyager2/lib/client';
 import getUserModules from './user-modules';
 import { mount } from 'react-cosmos-loader';
-// import { dismissRuntimeErrors } from 'react-error-overlay';
+import { dismissRuntimeErrors } from 'react-error-overlay';
 
 import type {
   Modules,
@@ -12,7 +12,6 @@ import type {
 
 // eslint-disable-next-line no-undef
 const { containerQuerySelector } = COSMOS_CONFIG;
-const dismissRuntimeErrors = () => {};
 
 export default function() {
   const {


### PR DESCRIPTION
Beginning of the implementation for [Dismiss run time error overlay on fixture change #521](https://github.com/react-cosmos/react-cosmos/issues/521)

Work in progress.

Notes/questions:
- [ ] `react-error-overlay` still needs to be published with [@skidding's PR](https://github.com/facebookincubator/create-react-app/pull/3414), until then we are assuming it will be versioned `v3.1.0`
- [x] `react-error-overlay` is imported in `react-cosmos-loader` but is in the dependency list of `react-cosmos` - should it be moved to `react-cosmos-shared`?
- [x] preferably `react-cosmos-loader` shouldn't even know about `react-error-overlay` - how to tackle this?
- [x] tests?

Big thanks to @skidding for his 24/7 availability to help!