### PR TITLE
Readme: `NODE_PATH` for create-react-app

### DIFF
--- a/README.md
+++ b/README.md
@@ -607,6 +607,14 @@ module.exports = {
   proxiesPath: 'src/cosmos.proxies'
 };
 ```
+If you are using the `NODE_PATH` environment variable for absolute imports, make sure to include that as part of the cosmos script:
+
+```js
+// package.json
+"scripts": {
+  "cosmos": "NODE_PATH=./src cosmos"
+}
+```
 
 Also make sure to:
 - Put [proxies](#proxies) in the `src` dir–the only place included by the CRA Babel loader


### PR DESCRIPTION
Included instructions on how to configure the `NODE_PATH` environment variable for their create-react-app setup in order to absolute import from the NODE_PATH path.