### PR TITLE
fix: update fixture documentation 

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,7 +244,7 @@ It is also possible to export an array of fixtures from a single file. The above
 ```js
 export default [{
   component: SearchBox,
-  namespace: 'Searching for pets'
+  namespace: 'Searching for pets',
   name: 'Dog search',
   state: {
     searchQuery: 'Who let the dogs out?'
@@ -252,7 +252,7 @@ export default [{
 },
 {
   component: SearchBox,
-  namespace: 'Searching for pets'
+  namespace: 'Searching for pets',
   name: 'Dog search',
   state: {
     searchQuery: 'où est le chat?'

--- a/README.md
+++ b/README.md
@@ -229,6 +229,37 @@ export default {
 };
 ```
 
+#### Other fixture Properties
+
+```
+{
+  name: // string - specify a title for the fixture. Otherwise it will default to the relevant component name
+  
+  namespace: // string - allows nesting of fixtures which share the same namespace
+}
+```
+
+It is also possible to export an array of fixtures from a single file. The above properties can be particularly useful in this case. For example
+
+```js
+export default [{
+  component: SearchBox,
+  namespace: 'Searching for pets'
+  name: 'Dog search',
+  state: {
+    searchQuery: 'Who let the dogs out?'
+  }
+},
+{
+  component: SearchBox,
+  namespace: 'Searching for pets'
+  name: 'Dog search',
+  state: {
+    searchQuery: 'où est le chat?'
+  }
+}]
+```
+
 ### Proxies
 
 #### What's a proxy?


### PR DESCRIPTION
Fixtures can be exported as an array, and also allow for name and namespace properties. These features are not currently mentioned in the documentation. I've added a brief description of these properties, and an example of exporting an array of fixtures.