### PR TITLE
Update react-error-overlay for #521

### DIFF
--- a/packages/react-cosmos/package.json
+++ b/packages/react-cosmos/package.json
@@ -22,7 +22,7 @@
     "react-cosmos-voyager": "^3.1.1",
     "react-cosmos-voyager2": "^3.1.1",
     "react-dev-utils": "^4.2.1",
-    "react-error-overlay": "^3.0.0",
+    "react-error-overlay": "^4.0.0",
     "resolve-from": "^3.0.0",
     "webpack-dev-middleware": "^1.12.0",
     "webpack-hot-middleware": "^2.18.2",

--- a/packages/react-cosmos/src/client/__tests__/mount/new-fixtures.js
+++ b/packages/react-cosmos/src/client/__tests__/mount/new-fixtures.js
@@ -1,7 +1,5 @@
 import { mount as mountLoader } from 'react-cosmos-loader';
-// import { dismissRuntimeErrors } from 'react-error-overlay';
-
-const dismissRuntimeErrors = () => {};
+import { dismissRuntimeErrors } from 'react-error-overlay';
 
 jest.mock('react-cosmos-loader', () => ({
   __esModule: true,
@@ -88,7 +86,7 @@ test('sends containerQuerySelector to loader', () => {
   });
 });
 
-test.skip('sends dismissRuntimeErrors to loader', () => {
+test('sends dismissRuntimeErrors to loader', () => {
   expect(mountLoader.mock.calls[0][0].dismissRuntimeErrors).toBe(
     dismissRuntimeErrors
   );

--- a/packages/react-cosmos/src/client/mount.js
+++ b/packages/react-cosmos/src/client/mount.js
@@ -2,7 +2,7 @@ import { importModule } from 'react-cosmos-shared';
 import { getComponents } from 'react-cosmos-voyager2/lib/client';
 import getUserModules from './user-modules';
 import { mount } from 'react-cosmos-loader';
-// import { dismissRuntimeErrors } from 'react-error-overlay';
+import { dismissRuntimeErrors } from 'react-error-overlay';
 
 import type { LoaderOpts } from 'react-cosmos-shared/src/types';
 import type {
@@ -13,7 +13,6 @@ import type {
 
 // eslint-disable-next-line no-undef
 const loaderOpts: LoaderOpts = COSMOS_CONFIG;
-const dismissRuntimeErrors = () => {};
 
 export default function() {
   const {


### PR DESCRIPTION
Updated react-error-overlay and reverted commit 57e5febd0ff52fe6774956ad945b06eafd7d2754 in order to make #521 completely functional.