### PR TITLE
Create stable Jest snapshots when using router-proxy

### DIFF
--- a/packages/react-cosmos-router-proxy/package.json
+++ b/packages/react-cosmos-router-proxy/package.json
@@ -14,7 +14,8 @@
     "url": "^0.11.0"
   },
   "devDependencies": {
-    "react-router": "^4.1.2"
+    "react-router": "^4.1.2",
+    "enzyme-to-json": "^3.3.0"
   },
   "xo": false
 }

--- a/packages/react-cosmos-router-proxy/src/__fixtures__/stableKeys.js
+++ b/packages/react-cosmos-router-proxy/src/__fixtures__/stableKeys.js
@@ -1,0 +1,11 @@
+import React from 'react';
+import { withRouter } from 'react-router';
+
+const MyComponent = () => <div>MyComponent</div>;
+const MyComponentWithRouter = withRouter(MyComponent);
+
+export default {
+  component: MyComponentWithRouter,
+  url: '/',
+  props: {}
+};

--- a/packages/react-cosmos-router-proxy/src/__tests__/__snapshots__/stable-snapshots.js.snap
+++ b/packages/react-cosmos-router-proxy/src/__tests__/__snapshots__/stable-snapshots.js.snap
@@ -1,0 +1,65 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`snapshot is stable 1`] = `
+<withRouter(MyComponent)>
+  <Route
+    render={[Function]}
+  >
+    <MyComponent
+      history={
+        Object {
+          "action": "POP",
+          "block": [Function],
+          "canGo": [Function],
+          "createHref": [Function],
+          "entries": Array [
+            Object {
+              "hash": "",
+              "key": "mocked",
+              "pathname": "/",
+              "search": "",
+              "state": undefined,
+            },
+          ],
+          "go": [Function],
+          "goBack": [Function],
+          "goForward": [Function],
+          "index": 0,
+          "length": 1,
+          "listen": [Function],
+          "location": Object {
+            "hash": "",
+            "key": "mocked",
+            "pathname": "/",
+            "search": "",
+            "state": undefined,
+          },
+          "push": [Function],
+          "replace": [Function],
+        }
+      }
+      location={
+        Object {
+          "hash": "",
+          "key": "mocked",
+          "pathname": "/",
+          "search": "",
+          "state": undefined,
+        }
+      }
+      match={
+        Object {
+          "isExact": true,
+          "params": Object {},
+          "path": "/",
+          "url": "/",
+        }
+      }
+    >
+      <div>
+        MyComponent
+      </div>
+    </MyComponent>
+  </Route>
+</withRouter(MyComponent)>
+`;

--- a/packages/react-cosmos-router-proxy/src/__tests__/just-url.js
+++ b/packages/react-cosmos-router-proxy/src/__tests__/just-url.js
@@ -107,6 +107,7 @@ describe('MemoryRouter', () => {
       expect(routerProps.initialEntries).toEqual([
         {
           hash: '#hash',
+          key: 'mocked',
           pathname: '/foo-route',
           search: '?bar=true',
           state: { someState: true }

--- a/packages/react-cosmos-router-proxy/src/__tests__/route.js
+++ b/packages/react-cosmos-router-proxy/src/__tests__/route.js
@@ -108,6 +108,7 @@ describe('MemoryRouter', () => {
         {
           hash: null,
           pathname: '/route/foo',
+          key: 'mocked',
           search: null,
           state: undefined
         }

--- a/packages/react-cosmos-router-proxy/src/__tests__/stable-snapshots.js
+++ b/packages/react-cosmos-router-proxy/src/__tests__/stable-snapshots.js
@@ -1,0 +1,27 @@
+import createTestContext from 'react-cosmos-test/enzyme';
+import fixture from '../__fixtures__/stableKeys';
+import createRouterProxy from '../';
+import toJson from 'enzyme-to-json';
+
+const proxies = [createRouterProxy()];
+
+const { mount, getWrapper } = createTestContext({ fixture, proxies });
+
+test('props are stable', () => {
+  mount();
+  const componentOneLocationPropKey = getWrapper()
+    .find('MyComponent')
+    .props().location.key;
+
+  mount();
+  const componentTwoLocationPropKey = getWrapper()
+    .find('MyComponent')
+    .props().location.key;
+
+  expect(componentOneLocationPropKey).toEqual(componentTwoLocationPropKey);
+});
+
+test('snapshot is stable', () => {
+  mount();
+  expect(toJson(getWrapper())).toMatchSnapshot();
+});

--- a/packages/react-cosmos-router-proxy/src/index.js
+++ b/packages/react-cosmos-router-proxy/src/index.js
@@ -11,6 +11,7 @@ function buildLocation(url, locationState) {
     pathname,
     search,
     hash,
+    key: 'mocked',
     state: locationState
   };
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3315,6 +3315,12 @@ enzyme-adapter-utils@^1.1.0:
     object.assign "^4.0.4"
     prop-types "^15.5.10"
 
+enzyme-to-json@^3.3.0:
+  version "3.3.1"
+  resolved "https://registry.yarnpkg.com/enzyme-to-json/-/enzyme-to-json-3.3.1.tgz#64239dcd417e2fb552f4baa6632de4744b9b5b93"
+  dependencies:
+    lodash "^4.17.4"
+
 enzyme@^3.1.1:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/enzyme/-/enzyme-3.2.0.tgz#998bdcda0fc71b8764a0017f7cc692c943f54a7a"


### PR DESCRIPTION
When using the `react-cosmos-router-proxy`, any Jest snapshots you create that have `location` or `history` props from `withRouter` or `Route` are unstable. This is because `react-router` will calculate a random `key` value as one of the props for `location` objects.

This PR alleviates most of this issue, by initializing the `MemoryRouter` with a stable key for the `url`.
https://github.com/ReactTraining/react-router/issues/5579#issuecomment-333401692