### PR TITLE
Support fixture call expression exports

### DIFF
--- a/packages/react-cosmos-voyager2/src/server/__tests__/esm/single-fn-call/__fsmocks__/Italic.js
+++ b/packages/react-cosmos-voyager2/src/server/__tests__/esm/single-fn-call/__fsmocks__/Italic.js
@@ -1,0 +1,5 @@
+// @flow
+
+import React from 'react';
+
+export const Italic = ({ name }: { name: string }) => <em>{name}</em>;

--- a/packages/react-cosmos-voyager2/src/server/__tests__/esm/single-fn-call/__fsmocks__/create-fixture.js
+++ b/packages/react-cosmos-voyager2/src/server/__tests__/esm/single-fn-call/__fsmocks__/create-fixture.js
@@ -1,0 +1,12 @@
+// @flow
+
+import type { Node, ComponentType } from 'react';
+
+export function createFixture<P: {}, C: ComponentType<P>>(fixture: {
+  component: C,
+  name?: string,
+  props?: P,
+  children?: Node
+}) {
+  return fixture;
+}

--- a/packages/react-cosmos-voyager2/src/server/__tests__/esm/single-fn-call/__fsmocks__/fixture.js
+++ b/packages/react-cosmos-voyager2/src/server/__tests__/esm/single-fn-call/__fsmocks__/fixture.js
@@ -1,0 +1,11 @@
+// @flow
+
+import { createFixture } from './create-fixture';
+import { Italic } from './Italic';
+
+export default createFixture({
+  component: Italic,
+  props: {
+    name: 'John'
+  }
+});

--- a/packages/react-cosmos-voyager2/src/server/__tests__/esm/single-fn-call/index.js
+++ b/packages/react-cosmos-voyager2/src/server/__tests__/esm/single-fn-call/index.js
@@ -1,0 +1,30 @@
+// @flow
+
+import { join } from 'path';
+import { findFixtureFiles } from '../../../find-fixture-files';
+
+const { resolve } = require;
+
+describe('ES module / Single fixture with function call export', () => {
+  let files;
+
+  beforeEach(async () => {
+    files = await findFixtureFiles({
+      rootPath: join(__dirname, '__fsmocks__')
+    });
+  });
+
+  it('has fixture path', () => {
+    expect(files[0].filePath).toBe(resolve('./__fsmocks__/fixture'));
+  });
+
+  it('has component name', () => {
+    expect(files[0].components[0].name).toBe('Italic');
+  });
+
+  it('has component path', () => {
+    expect(files[0].components[0].filePath).toBe(
+      resolve('./__fsmocks__/Italic')
+    );
+  });
+});


### PR DESCRIPTION
Related to #560, specifically @maxsalven's [comment](https://github.com/react-cosmos/react-cosmos/issues/560#issuecomment-353928361). This doesn't bundle the `createFixture` helper into Cosmos, so anyone who wishes to add types to their fixtures will have to host a copy of it for now. But this PR extends the fixture parser to be able to detect component paths from fixtures where a call expression (ie. function call) is exported instead of an object or array of object.