### PR TITLE
Includes StateProxy as the last proxy when using Loader's createContext

### DIFF
--- a/examples/local-state/components/Counter/Counter.test.js
+++ b/examples/local-state/components/Counter/Counter.test.js
@@ -1,0 +1,29 @@
+import createTestContext from 'react-cosmos-test/enzyme';
+import until from 'async-until';
+import fiveClicksFixture from './__fixtures__/five-clicks';
+
+const { mount, get, getWrapper } = createTestContext({
+  fixture: fiveClicksFixture
+});
+
+beforeEach(mount);
+
+describe('local state example', () => {
+  it('has been clicked five times', () => {
+    expect(get('state')).toEqual({ value: 5 });
+  });
+
+  it('is an awesome counter', () => {
+    expect(get('props')).toEqual(
+      expect.objectContaining({ name: 'Awesome Counter' })
+    );
+  });
+
+  it('increments the counter when the button is clicked', async () => {
+    getWrapper()
+      .find('button')
+      .simulate('click');
+
+    await until(() => get('state').value === 6);
+  });
+});

--- a/examples/local-state/components/Counter/__tests__/Counter.js
+++ b/examples/local-state/components/Counter/__tests__/Counter.js
@@ -1,6 +1,6 @@
 import createTestContext from 'react-cosmos-test/enzyme';
 import until from 'async-until';
-import fiveClicksFixture from './__fixtures__/five-clicks';
+import fiveClicksFixture from '../__fixtures__/five-clicks';
 
 const { mount, get, getWrapper } = createTestContext({
   fixture: fiveClicksFixture

--- a/examples/local-state/package.json
+++ b/examples/local-state/package.json
@@ -5,11 +5,16 @@
   "repository": "https://github.com/react-cosmos/react-cosmos/tree/master/examples/local-state",
   "license": "MIT",
   "scripts": {
-    "start": "cosmos"
+    "start": "cosmos",
+    "test": "node ../../node_modules/jest-cli/bin/jest.js --watch --config ../../jest.config.json"
   },
   "dependencies": {
     "react-cosmos": "^3.7.1"
   },
   "xo": false,
-  "private": true
+  "private": true,
+  "devDependencies": {
+    "async-until": "^1.0.0",
+    "react-cosmos-test": "^3.6.1"
+  }
 }

--- a/packages/react-cosmos-loader/src/__tests__/create-context.js
+++ b/packages/react-cosmos-loader/src/__tests__/create-context.js
@@ -6,6 +6,15 @@ import afterPendingPromises from 'after-pending-promises';
 import Loader from '../components/Loader';
 import { createContext as _createContext } from '../create-context';
 
+function mockStateProxy(props) {
+  const { nextProxy } = props;
+  return <nextProxy.value {...props} nextProxy={nextProxy.next()} />;
+}
+
+jest.mock('react-cosmos-state-proxy', () => {
+  return jest.fn().mockImplementation(() => mockStateProxy);
+});
+
 function ProxyA(props) {
   const { nextProxy } = props;
   return <nextProxy.value {...props} nextProxy={nextProxy.next()} />;
@@ -75,6 +84,17 @@ it('includes user proxies in Loader props', async () => {
   const element = getElementFromLastRendererCall();
   expect(element.props.proxies).toContain(ProxyA);
   expect(element.props.proxies).toContain(ProxyB);
+});
+
+it('includes the StateProxy as the last proxy', async () => {
+  const { mount } = createContext({ renderer, proxies, fixture });
+  await mount();
+
+  const element = getElementFromLastRendererCall();
+
+  expect(element.props.proxies[element.props.proxies.length - 1]).toBe(
+    mockStateProxy
+  );
 });
 
 it('calls renderer with loaderOptions', async () => {

--- a/packages/react-cosmos-loader/src/__tests__/mount.js
+++ b/packages/react-cosmos-loader/src/__tests__/mount.js
@@ -10,7 +10,6 @@ const mockProxy = () => {};
 const mockLoaderOpts = { containerQuerySelector: '#app123' };
 
 const mockRenderer = {};
-const mockStateProxy = {};
 const mockErrorCatchProxy = {};
 const mockDismissRuntimeErrors = () => {};
 

--- a/packages/react-cosmos-loader/src/__tests__/mount.js
+++ b/packages/react-cosmos-loader/src/__tests__/mount.js
@@ -14,7 +14,6 @@ const mockStateProxy = {};
 const mockErrorCatchProxy = {};
 const mockDismissRuntimeErrors = () => {};
 
-jest.mock('react-cosmos-state-proxy', () => jest.fn(() => mockStateProxy));
 jest.mock('../components/ErrorCatchProxy', () =>
   jest.fn(() => mockErrorCatchProxy)
 );
@@ -57,10 +56,6 @@ it('passes user proxies to loaderConnect', () => {
 
 it('includes ErrorCatchProxy', () => {
   expect(getProxiesFromLastCall()).toContain(mockErrorCatchProxy);
-});
-
-it('includes StateProxy', () => {
-  expect(getProxiesFromLastCall()).toContain(mockStateProxy);
 });
 
 it('passes fixtures to loaderConnect', () => {

--- a/packages/react-cosmos-loader/src/create-context.js
+++ b/packages/react-cosmos-loader/src/create-context.js
@@ -2,6 +2,7 @@
 
 import until from 'async-until';
 import React from 'react';
+import createStateProxy from 'react-cosmos-state-proxy';
 import Loader from './components/Loader';
 import { isComponentClass } from './utils/is-component-class';
 
@@ -39,6 +40,7 @@ export function createContext(args: ContextArgs): ContextFunctions {
   let updatedFixture = { ...fixture };
   let compRefCalled = false;
   let compRef: ?ComponentRef;
+  let StateProxy;
 
   function getRef() {
     if (!compRef) {
@@ -82,9 +84,13 @@ export function createContext(args: ContextArgs): ContextFunctions {
           updatedFixture = { ...fixture };
         }
 
+        if (!StateProxy) {
+          StateProxy = createStateProxy();
+        }
+
         wrapper = renderer(
           <Loader
-            proxies={proxies}
+            proxies={[...proxies, StateProxy]}
             fixture={updatedFixture}
             onComponentRef={ref => {
               // Sometimes the component unmounts instantly (eg. redirects on

--- a/packages/react-cosmos-loader/src/create-context.js
+++ b/packages/react-cosmos-loader/src/create-context.js
@@ -85,7 +85,7 @@ export function createContext(args: ContextArgs): ContextFunctions {
         }
 
         if (!StateProxy) {
-          StateProxy = createStateProxy();
+          StateProxy = createStateProxy({ updateInterval: 50 });
         }
 
         wrapper = renderer(

--- a/packages/react-cosmos-loader/src/create-context.js
+++ b/packages/react-cosmos-loader/src/create-context.js
@@ -14,6 +14,7 @@ import type {
 } from './types';
 
 let wrapper: ?Wrapper;
+const StateProxy = createStateProxy({ updateInterval: 50 });
 
 /**
  * Generalized way to render fixtures, without any assumptions on the renderer.
@@ -40,7 +41,6 @@ export function createContext(args: ContextArgs): ContextFunctions {
   let updatedFixture = { ...fixture };
   let compRefCalled = false;
   let compRef: ?ComponentRef;
-  let StateProxy;
 
   function getRef() {
     if (!compRef) {
@@ -82,10 +82,6 @@ export function createContext(args: ContextArgs): ContextFunctions {
 
           // Bring fixture to its initial state
           updatedFixture = { ...fixture };
-        }
-
-        if (!StateProxy) {
-          StateProxy = createStateProxy({ updateInterval: 50 });
         }
 
         wrapper = renderer(

--- a/packages/react-cosmos-loader/src/mount.js
+++ b/packages/react-cosmos-loader/src/mount.js
@@ -1,6 +1,5 @@
 // @flow
 
-import createStateProxy from 'react-cosmos-state-proxy';
 import createErrorCatchProxy from './components/ErrorCatchProxy';
 import { createDomRenderer } from './dom-renderer';
 import { connectLoader } from './connect-loader';
@@ -15,7 +14,6 @@ type Args = {
   dismissRuntimeErrors?: Function
 };
 
-let StateProxy;
 let ErrorCatchProxy;
 
 export function mount(args: Args) {
@@ -23,14 +21,13 @@ export function mount(args: Args) {
   const renderer = createDomRenderer(loaderOpts);
 
   // Reuse proxy instances
-  if (!StateProxy) {
-    StateProxy = createStateProxy();
+  if (!ErrorCatchProxy) {
     ErrorCatchProxy = createErrorCatchProxy();
   }
 
   connectLoader({
     renderer,
-    proxies: [ErrorCatchProxy, ...proxies, StateProxy],
+    proxies: [ErrorCatchProxy, ...proxies],
     fixtures,
     dismissRuntimeErrors
   });


### PR DESCRIPTION
> The problem solved by this PR has been referenced in many different discussions, but not in a specific issue afaik.

Problem
---
`StateProxy` is only used [when mounting the loader directly](https://github.com/react-cosmos/react-cosmos/blob/763ccd495533a3ff54b525bcf1f589644909187d/packages/react-cosmos-loader/src/mount.js#L25-L33), but not when using the generic way to get the loader with `createContext`.

Let's say you need `StateProxy` to run some assertions on your components: you need to manually add it to your `cosmos.proxies.js` list to have access to it. This will result in a duplication of the proxy on the UI.

(Possible) Solution
---
Include `StateProxy` in `createContext` so it's consistent with the rest of cosmos!

This enables test like the one in the diff 🎉 