### PR TITLE
feat: update redux-proxy to receive new props

### DIFF
--- a/packages/react-cosmos-redux-proxy/src/__tests__/index.js
+++ b/packages/react-cosmos-redux-proxy/src/__tests__/index.js
@@ -77,6 +77,10 @@ const commonTests = () => {
     childProps.onFixtureUpdate({});
     expect(onFixtureUpdate.mock.calls).toHaveLength(1);
   });
+
+  test('sets the key to 0', () => {
+    expect(childWrapper.key()).toBe('0');
+  });
 };
 
 describe('fixture without Redux state', () => {
@@ -158,6 +162,33 @@ describe('fixture with Redux state', () => {
 
   test('disables local state', () => {
     expect(childProps.disableLocalState).toBe(true);
+  });
+
+  describe('on receiving new props', () => {
+    beforeAll(() => {
+      wrapper.setProps({
+        fixture: {
+          reduxState: {
+            counter: 11
+          }
+        }
+      });
+    });
+    it('unsubscribes from current store', () => {
+      expect(storeUnsubscribeMock).toHaveBeenCalled();
+    });
+
+    it('creates a new store with updated state', () => {
+      expect(createStore.mock.calls.length).toBe(2);
+    });
+
+    it('subscribes to new store', () => {
+      expect(storeMock.subscribe.mock.calls.length).toBe(2);
+    });
+
+    it('increments the key of the rendered component', () => {
+      expect(wrapper.key()).toBe('1');
+    });
   });
 
   describe('on unmount', () => {


### PR DESCRIPTION
I haven't put the documentation for 'set' back in since I haven't had a chance to go through the other proxies yet.  