### PR TITLE
fix(bin/cosmos*.js): check the local process.env variables

### DIFF
--- a/packages/react-cosmos/bin/cosmos-export.js
+++ b/packages/react-cosmos/bin/cosmos-export.js
@@ -1,8 +1,8 @@
 #!/usr/bin/env node
 
 // Do this as the first thing so that any code reading it knows the right env.
-process.env.BABEL_ENV = 'production';
-process.env.NODE_ENV = 'production';
+process.env.BABEL_ENV = process.env.BABEL_ENV || 'production';
+process.env.NODE_ENV = process.env.NODE_ENV || 'production';
 
 const startExport = require('../lib/server/export').default;
 

--- a/packages/react-cosmos/bin/cosmos.js
+++ b/packages/react-cosmos/bin/cosmos.js
@@ -1,8 +1,8 @@
 #!/usr/bin/env node
 
 // Do this as the first thing so that any code reading it knows the right env.
-process.env.BABEL_ENV = 'development';
-process.env.NODE_ENV = 'development';
+process.env.BABEL_ENV = process.env.BABEL_ENV || 'development';
+process.env.NODE_ENV = process.env.NODE_ENV || 'development';
 
 const startServer = require('../lib/server/server').default;
 


### PR DESCRIPTION
Need to check whether downstream consumers have passed process.env to our cosmos and cosmos-export playground scripts before hardcoding to development or production respectively. to fix issue #626 