### PR TITLE
Allow parsing css from node_modules by default

### DIFF
--- a/packages/react-cosmos/src/server/__tests__/default-webpack-config/style-css-loader.js
+++ b/packages/react-cosmos/src/server/__tests__/default-webpack-config/style-css-loader.js
@@ -18,11 +18,21 @@ jest.mock('import-from', () => ({
   }
 }));
 
-it('includes style-loader + css-loader', () => {
+it('parses personal css with style-loader + css-loader', () => {
   const config = getDefaultWebpackConfig('/foo/path');
   expect(config.module.rules).toContainEqual({
     test: /\.css$/,
     loader: '/style/path!/css/path',
     exclude: /node_modules/
+  });
+});
+
+it('parses 3rd party css with style-loader + css-loader', () => {
+  const config = getDefaultWebpackConfig('/foo/path');
+
+  expect(config.module.rules).toContainEqual({
+    test: /\.css$/,
+    loader: '/style/path!/css/path',
+    include: /node_modules/
   });
 });

--- a/packages/react-cosmos/src/server/__tests__/default-webpack-config/style-loader.js
+++ b/packages/react-cosmos/src/server/__tests__/default-webpack-config/style-loader.js
@@ -17,11 +17,21 @@ jest.mock('import-from', () => ({
   }
 }));
 
-it('includes style-loader', () => {
+it('parses personal css with style-loader', () => {
   const config = getDefaultWebpackConfig('/foo/path');
   expect(config.module.rules).toContainEqual({
     test: /\.css$/,
     loader: '/style/path',
     exclude: /node_modules/
+  });
+});
+
+it('parses 3rd party css with style-loader', () => {
+  const config = getDefaultWebpackConfig('/foo/path');
+
+  expect(config.module.rules).toContainEqual({
+    test: /\.css$/,
+    loader: '/style/path',
+    include: /node_modules/
   });
 });

--- a/packages/react-cosmos/src/server/default-webpack-config.js
+++ b/packages/react-cosmos/src/server/default-webpack-config.js
@@ -29,6 +29,15 @@ export default function getDefaultWebpackConfig(rootPath) {
         : styleLoaderPath,
       exclude: /node_modules/
     });
+
+    // Preprocess 3rd party .css files located in node_modules
+    rules.push({
+      test: /\.css$/,
+      loader: cssLoaderPath
+        ? `${styleLoaderPath}!${cssLoaderPath}`
+        : styleLoaderPath,
+      include: /node_modules/
+    });
   }
 
   if (jsonLoaderPath) {


### PR DESCRIPTION
> Fixes #631 

## Problem
One uses a 3rd party library such as Material UI or Semantic UI in their project, and want Cosmos to consume the same CSS.

They don't have a custom webpack config.

Cosmos fails, unable to parse the CSS imported from `node_modules`

## Proposed solution

Two loaders entries (with two different tests) to bring the most clarity to both users and maintainers about what's going on with the default webpack config:
- allow importing personal CSS
- allow importing 3rd party CSS

