### PR TITLE
Add support for IE 11

### DIFF
--- a/packages/react-cosmos-playground/package.json
+++ b/packages/react-cosmos-playground/package.json
@@ -23,7 +23,8 @@
     "react-cosmos-loader": "^4.0.0-rc.1",
     "react-cosmos-state-proxy": "^4.0.0-rc.1",
     "react-cosmos-test": "^4.0.0-rc.1",
-    "react-querystring-router": "^4.0.0-rc.1"
+    "react-querystring-router": "^4.0.0-rc.1",
+    "whatwg-fetch": "^2.0.4"
   },
   "xo": false
 }

--- a/packages/react-cosmos-playground/webpack.config.js
+++ b/packages/react-cosmos-playground/webpack.config.js
@@ -22,7 +22,7 @@ module.exports = {
   // Besides other advantages, cheap-module-source-map is compatible with
   // React.componentDidCatch https://github.com/facebook/react/issues/10441
   devtool: 'cheap-module-source-map',
-  entry: src,
+  entry: ['whatwg-fetch', src],
   output: {
     libraryTarget: 'umd',
     library: 'mountPlayground',

--- a/packages/react-cosmos/package.json
+++ b/packages/react-cosmos/package.json
@@ -29,5 +29,8 @@
     "cosmos-export": "./bin/cosmos-export.js",
     "print-fixture-files": "./bin/print-fixture-files.js"
   },
-  "xo": false
+  "xo": false,
+  "devDependencies": {
+    "whatwg-fetch": "^2.0.4"
+  }
 }

--- a/packages/react-cosmos/package.json
+++ b/packages/react-cosmos/package.json
@@ -5,12 +5,14 @@
   "repository": "https://github.com/react-cosmos/react-cosmos/tree/master/packages/react-cosmos",
   "license": "MIT",
   "dependencies": {
+    "babel-polyfill": "^6.26.0",
     "express": "^4.15.4",
     "fs-extra": "^4.0.1",
     "glob": "^7.1.1",
     "http-proxy-middleware": "^0.17.4",
     "import-from": "^2.1.0",
     "lodash.omit": "^4.5.0",
+    "object.values": "^1.0.4",
     "react-cosmos-config": "^4.0.0-rc.1",
     "react-cosmos-loader": "^4.0.0-rc.1",
     "react-cosmos-playground": "^4.0.0-rc.1",
@@ -30,7 +32,5 @@
     "print-fixture-files": "./bin/print-fixture-files.js"
   },
   "xo": false,
-  "devDependencies": {
-    "whatwg-fetch": "^2.0.4"
-  }
+  "devDependencies": {}
 }

--- a/packages/react-cosmos/src/client/loader-entry.js
+++ b/packages/react-cosmos/src/client/loader-entry.js
@@ -1,5 +1,11 @@
 import './react-devtools-hook';
 import './react-error-overlay';
+import 'babel-polyfill';
+import values from 'object.values';
+
+if (!Object.values) {
+  values.shim();
+}
 
 const isDev = process.env.NODE_ENV === 'development';
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -11649,6 +11649,10 @@ whatwg-fetch@>=0.10.0:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/whatwg-fetch/-/whatwg-fetch-2.0.3.tgz#9c84ec2dcf68187ff00bc64e1274b442176e1c84"
 
+whatwg-fetch@^2.0.4:
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/whatwg-fetch/-/whatwg-fetch-2.0.4.tgz#dde6a5df315f9d39991aa17621853d720b85566f"
+
 whatwg-url@^6.4.0:
   version "6.4.0"
   resolved "https://registry.yarnpkg.com/whatwg-url/-/whatwg-url-6.4.0.tgz#08fdf2b9e872783a7a1f6216260a1d66cc722e08"


### PR DESCRIPTION
In `react-cosmos-playground` I had to add a polyfill for `fetch` and in `react-cosmos` I added a polyfill for `Object.values` and `Promise`

This let's everything work in IE 11