### PR TITLE
docs: Update readme with testing tip for enzyme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1033,6 +1033,8 @@ test('renders hello', () => {
 });
 ```
 
+> Enzyme v3 requires you to call `wrapper.update` after a component updates, usually in response to an event [enzyme thread](https://github.com/airbnb/enzyme/issues/1163). The cosmos-enzyme wrapper tries to alleviate this by updating the wrapper whenever we call `getWrapper()`. If you find that your components don't seem to be updating in tests this may be due to to assigning `getWrapper()` to a variable and expecting it to change.
+
 But this is not the only way. As we'll see below, we can also mount fixtures using with a custom renderer.
 
 #### Using a custom renderer


### PR DESCRIPTION
I don't know if this is just something a bit weird in my setup but it took me long enough to figure this out to justify creating a PR.

In my tests I found that this code did not work (using layers of mobx and [formik](https://github.com/jaredpalmer/formik/tree/master/src), basically the change event is supposed to update the value of the input):
```jsx
const wrapper = getWrapper();
wrapper.find('[role="gridcell"] input')
  .at(0)
  .simulate('change', {
    target: { name: 'translation.string', value: 'My new value' }
  });
expect(
  wrapper
    .find('[role="gridcell"]')
    .at(4)
).toMatchSnapshot();
```
But when changed to the following it did work (also calling `getRootWrapper().update()` didn't work either).

```jsx
getWrapper()
  .find('[role="gridcell"] input')
  .at(0)
  .simulate('change', {
    target: { name: 'translation.string', value: 'My new value' }
  });
expect(
  getWrapper()
    .find('[role="gridcell"]')
    .at(4)
).toMatchSnapshot();
```