### PR TITLE
fix: Allow fixture namespaces with slashes inside

### DIFF
--- a/packages/react-cosmos-playground/src/components/FixtureList/__tests__/data-mapper.js
+++ b/packages/react-cosmos-playground/src/components/FixtureList/__tests__/data-mapper.js
@@ -325,7 +325,10 @@ test('deals with components with namespaced fixtures', () => {
     'dirA/Component1': ['fixtureA', 'fixtureB'],
     'dirB/Component2': [
       'Some folder/fixtureA',
-      'Some folder/fixtureB',
+      // Note that only one level of fixture namespace is currently supported
+      // This is a regression case for
+      //  https://github.com/react-cosmos/react-cosmos/issues/670
+      'Some folder/nested/fixtureB',
       'Another folder/fixtureC',
       'fixtureD'
     ]
@@ -405,13 +408,21 @@ test('deals with components with namespaced fixtures', () => {
                     component: 'dirB/Component2',
                     fixture: 'Some folder/fixtureA'
                   }
-                },
+                }
+              ]
+            },
+            {
+              name: 'Some folder/nested',
+              type: 'fixtureDirectory',
+              expanded: true,
+              path: 'dirB/Component2/Some folder/nested',
+              children: [
                 {
                   name: 'fixtureB',
                   type: 'fixture',
                   urlParams: {
                     component: 'dirB/Component2',
-                    fixture: 'Some folder/fixtureB'
+                    fixture: 'Some folder/nested/fixtureB'
                   }
                 }
               ]

--- a/packages/react-cosmos-playground/src/components/FixtureList/data-mapper.js
+++ b/packages/react-cosmos-playground/src/components/FixtureList/data-mapper.js
@@ -15,15 +15,16 @@ function parseFixtureArray(componentName, fixtureArray, savedExpansionState) {
   const unnestedData = [];
 
   fixtureArray.forEach(fixturePath => {
-    const [pre, post] = fixturePath.split('/');
-    if (post) {
-      const [folderName, fixtureName] = [pre, post];
+    // Only one level of indentation is supported by the fixture namespace
+    const parts = fixturePath.split('/');
+    if (parts.length > 1) {
+      const fixtureName = parts.pop();
+      const folderName = parts.join('/');
       // fixturePath contains a folder
       nestedData[folderName] = nestedData[folderName] || [];
       nestedData[folderName].push(fixtureName);
     } else {
-      const fixtureName = pre;
-      unnestedData.push(fixtureName);
+      unnestedData.push(parts[0]);
     }
   });
 


### PR DESCRIPTION
And specify the one level limit to fixture nesting