### PR TITLE
fix: xhr proxy should resetup mocks in hot module mode

### DIFF
--- a/packages/react-cosmos-xhr-proxy/src/index.js
+++ b/packages/react-cosmos-xhr-proxy/src/index.js
@@ -24,6 +24,8 @@ export function createXhrProxy({ fixtureKey = 'xhr' }: Options = {}) {
         module.hot.status(status => {
           if (status === 'check') {
             xhrMock.teardown();
+          } else if (status === 'apply') {
+            this.mock();
           }
         });
       }


### PR DESCRIPTION
Currently webpack hot module handler removes the mocks but doesn’t re-add them, this fixes that.

The issue I was seeing was that when a module was hot loaded the xhrMocks were removed, meaning that subsequent requests went out to the internet not the xhrMock.