### PR TITLE
docs: semicolon in object literal typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -923,7 +923,7 @@ module.exports = {
       ...config,
       plugins: config.plugins.filter(
         p => !p.constructor || p.constructor.name !== 'OfflinePlugin'
-      );
+      )
     };
   }
 };


### PR DESCRIPTION
Fixed small typo with semicolon in module.exports object literal 😊