### PR TITLE
docs: proxiesPath outside of rootPath

### DIFF
--- a/README.md
+++ b/README.md
@@ -310,7 +310,7 @@ yarn add --dev react-cosmos-fetch-proxy react-cosmos-redux-proxy react-cosmos-ro
 
 Then create `cosmos.proxies.js` (in your project's root directory or next to cosmos.config.js) and export a list of proxies in the order they should load–from outermost to innermost.
 
-> `proxies.cosmos.js` requires compilation so you may need to place it next to your source files (eg. if the `src` dir is whitelisted in babel-loader). Use `proxiesPath` option to customize its location.
+> `proxies.cosmos.js` requires compilation so you may need to place it next to your source files (eg. if the `src` dir is whitelisted in babel-loader). Use [proxiesPath](docs/proxies-outside-source.md) option to customize its location.
 
 Here's an example where we mock the Fetch API and add Redux and React Router providers:
 

--- a/docs/proxies-outside-source.md
+++ b/docs/proxies-outside-source.md
@@ -1,0 +1,25 @@
+If your projects directory tree look similar to this:
+```
+projectFolder
+│
+└─── configFiles
+│   │
+│   └─── react-cosmos
+│       │
+│       └─── cosmos.config.js
+│       │
+│       └─── cosmos.proxies.js
+│   
+└─── src
+│   │
+│   └─── ...
+...
+```
+And you want to hold your `cosmos.proxies.js` outside of root directory you need to define `proxiesPath` in `cosmos.config.js` relatively to `rootPath`.
+```js
+module.exports = {
+    rootPath: '../../src/',
+    proxiesPath: '../../config/react-cosmos/cosmos.proxies',
+}
+```
+Then proxies path will be resolved like `path.join(rootPath, proxiesPath)`, so you can skip placing `cosmos.proxies.js` in src directory and instead keep it near config.


### PR DESCRIPTION
Since proxiesPath is always relative to rootPath this may be beneficial to [mention that in docs](https://github.com/react-cosmos/react-cosmos/issues/703).