### PR TITLE
Fixed persistent mocks between fixtures

### DIFF
--- a/README.md
+++ b/README.md
@@ -483,7 +483,7 @@ This proxy wraps your components with the `ApolloProvider` so they can render in
 Provide:
 
 * The GraphQL `endpoint` you send operations to
-* Or The `client` used in your app
+* Or The `client options object` used in your app
 
 ```js
 // cosmos.proxies.js
@@ -505,11 +505,11 @@ import createApolloProxy from 'react-cosmos-apollo-proxy';
 
 // option 2: use the client from your app
 
-import myConfiguredClient from './src/client.js';
+import myConfiguredClientOptions from './src/client.js';
 
 export default [
   createApolloProxy({
-    client: myConfiguredClient
+    clientOptions: myConfiguredClientOptions
   })
   // ...other proxies
 ];
@@ -517,7 +517,7 @@ export default [
 
 ##### "Live" behavior
 
-Once configured, your components enhanced by `react-apollo` will behave as they would normally in your app, sending operation via your own client or to the endpoint passed specified in `cosmos.proxies.js`.
+Once configured, your components enhanced by `react-apollo` will behave as they would normally in your app, sending operation via your own client options object or to the endpoint passed specified in `cosmos.proxies.js`.
 
 ##### Mocking a response with a result or an error
 

--- a/packages/react-cosmos-apollo-proxy/src/__tests__/client.js
+++ b/packages/react-cosmos-apollo-proxy/src/__tests__/client.js
@@ -125,9 +125,9 @@ describe('proxy configured with a client', () => {
     expect(wrapper.instance().client.cache).toBe(clientOptions.cache);
   });
 
-  //   it('connects to the Apollo DevTools', () => {
-  //     expect(parent.__APOLLO_CLIENT__).toBe(clientOptions);
-  //   });
+  it('connects to the Apollo DevTools', () => {
+    expect(parent.__APOLLO_CLIENT__).toBe(wrapper.instance().client);
+  });
 });
 
 describe('proxy configured with an endpoint', () => {

--- a/packages/react-cosmos-apollo-proxy/src/__tests__/client.js
+++ b/packages/react-cosmos-apollo-proxy/src/__tests__/client.js
@@ -1,6 +1,5 @@
 import React from 'react';
 import { mount } from 'enzyme';
-import { ApolloClient } from 'apollo-client';
 import { InMemoryCache, ID_KEY } from 'apollo-cache-inmemory';
 import { HttpLink } from 'apollo-link-http';
 import { graphql } from 'react-apollo';
@@ -103,7 +102,7 @@ describe('proxy configured with a client', () => {
       [ID_KEY]: 'Author:1'
     }
   };
-  let client;
+  let clientOptions;
 
   beforeAll(() => {
     fetchMock.post('https://xyz', { data: resolveWith });
@@ -114,21 +113,21 @@ describe('proxy configured with a client', () => {
   });
 
   beforeEach(() => {
-    client = new ApolloClient({
+    clientOptions = {
       cache: new InMemoryCache(),
       link: new HttpLink({ uri: 'https://xyz' })
-    });
+    };
 
-    setupTestWrapper({ proxyConfig: { client } });
+    setupTestWrapper({ proxyConfig: { clientOptions } });
   });
 
-  it('uses the client passed in the config', () => {
-    expect(wrapper.instance().client).toBe(client);
+  it('uses the clientOptions passed in the config', () => {
+    expect(wrapper.instance().client.cache).toBe(clientOptions.cache);
   });
 
-  it('connects to the Apollo DevTools', () => {
-    expect(parent.__APOLLO_CLIENT__).toBe(client);
-  });
+  //   it('connects to the Apollo DevTools', () => {
+  //     expect(parent.__APOLLO_CLIENT__).toBe(clientOptions);
+  //   });
 });
 
 describe('proxy configured with an endpoint', () => {

--- a/packages/react-cosmos-apollo-proxy/src/index.js
+++ b/packages/react-cosmos-apollo-proxy/src/index.js
@@ -11,7 +11,7 @@ const defaults = {
 };
 
 export function createApolloProxy(options) {
-  const { fixtureKey, endpoint, client } = {
+  const { fixtureKey, endpoint, clientOptions } = {
     ...defaults,
     ...options
   };
@@ -22,13 +22,13 @@ export function createApolloProxy(options) {
     constructor(props) {
       super(props);
 
-      if (!endpoint && !client) {
+      if (!endpoint && !clientOptions) {
         throw new Error(
           `
 It looks like the Apollo Proxy is not configured!
 Give it:
 - a GraphQL endpoint to send GraphQL operations to;
-- a configured Apollo Client (maybe the one you use in your app?);
+- a Apollo Client configuration object (maybe the one you use in your app?);
 Read more at: https://github.com/react-cosmos/react-cosmos#react-apollo-graphql.`
         );
       }
@@ -44,20 +44,20 @@ Read more at: https://github.com/react-cosmos/react-cosmos#react-apollo-graphql.
 
       const cache = new InMemoryCache();
 
-      this.client =
-        client ||
-        new ApolloClient({
+      const options = clientOptions || {
           cache,
           link: new HttpLink({ uri: endpoint })
-        });
+      };
 
-      if (isMockedFixture) {
-        this.client.link = createFixtureLink({
-          apolloFixture,
-          cache,
-          fixture: this.props.fixture
-        });
+      if(isMockedFixture) {
+          options.link = createFixtureLink({
+            apolloFixture,
+            cache,
+            fixture: this.props.fixture
+          });
       }
+
+      this.client = new ApolloClient(options);
 
       // enable the Apollo Client DevTools to recognize the Apollo Client instance
       parent.__APOLLO_CLIENT__ = this.client;

--- a/packages/react-cosmos-apollo-proxy/src/index.js
+++ b/packages/react-cosmos-apollo-proxy/src/index.js
@@ -45,16 +45,16 @@ Read more at: https://github.com/react-cosmos/react-cosmos#react-apollo-graphql.
       const cache = new InMemoryCache();
 
       const options = clientOptions || {
-          cache,
-          link: new HttpLink({ uri: endpoint })
+        cache,
+        link: new HttpLink({ uri: endpoint })
       };
 
-      if(isMockedFixture) {
-          options.link = createFixtureLink({
-            apolloFixture,
-            cache,
-            fixture: this.props.fixture
-          });
+      if (isMockedFixture) {
+        options.link = createFixtureLink({
+          apolloFixture,
+          cache,
+          fixture: this.props.fixture
+        });
       }
 
       this.client = new ApolloClient(options);


### PR DESCRIPTION
This is a PR to fix the following issues.
https://github.com/react-cosmos/react-cosmos/issues/698

I unfortunately had rewrite the "api" a bit so the user passed a client object otherwise I was unable to take in account user client options
