### PR TITLE
fix: Empty Apollo's cache when switching mocked fixture

### DIFF
--- a/packages/react-cosmos-apollo-proxy/src/index.js
+++ b/packages/react-cosmos-apollo-proxy/src/index.js
@@ -50,9 +50,11 @@ Read more at: https://github.com/react-cosmos/react-cosmos#react-apollo-graphql.
       };
 
       if (isMockedFixture) {
+        // ensure that the cache is not persisted between mocked fixtures
+        options.cache = cache;
         options.link = createFixtureLink({
           apolloFixture,
-          cache,
+          cache: options.cache,
           fixture: this.props.fixture
         });
       }


### PR DESCRIPTION
👋 hey there!

What's up?
---
When using an `ApolloProxy` defined with `clientOptions` and browsing mocked fixture, the cache is still persisted! 

![screen recording 2018-07-01 at 10 10 pm](https://user-images.githubusercontent.com/13962779/42155949-0641e7d8-7dea-11e8-9bb0-c0fcb2654b6b.gif)

Solution provided by this PR
---
If we are on a mocked fixture (`isMockedFixture`), be sure to use a `new` InMemoryCache` instance :smile:

![screen recording 2018-07-01 at 10 09 pm](https://user-images.githubusercontent.com/13962779/42155975-1a383aa8-7dea-11e8-81a6-17f65695fcb7.gif)

What could be better?
---
Changing (again) the API of the ApolloProxy to set the client options thanks to a function, so we are sure nothing is persisted in the module `cosmos.proxies.js` :thinking_face: