### PR TITLE
Allow errors objects in Apollo proxy

### DIFF
--- a/README.md
+++ b/README.md
@@ -630,6 +630,8 @@ export default {
 
 ##### Failing response
 
+You can use the `failWith` option to mock an apollo 'networkError', i.e. you did not get a successful response from the server (perhaps the internet connection is offline, or a 500 response was returned):
+
 ```js
 export default {
   component: Author,
@@ -639,6 +641,31 @@ export default {
   apollo: {
     failWith: {
       message: 'Something went bad, please try again!'
+    }
+  }
+};
+```
+
+To mock a valid response from an API which contains an errors object, you can use the following format:
+
+```js
+export default {
+  component: Author,
+  props: {
+    authorId: -1
+  },
+  apollo: {
+    resolveWith: {
+      data: {
+        author: null
+      },
+      errors: [
+        {
+          path: ['author'],
+          message: ['Author id -1 not found'],
+          locations: [{ line: 1, column: 0 }]
+        }
+      ]
     }
   }
 };

--- a/examples/apollo/components/Author.js
+++ b/examples/apollo/components/Author.js
@@ -49,21 +49,31 @@ export default class Author extends Component {
               <ul>
                 {author.posts.map(({ id: postId, title, votes }) => (
                   <Mutation key={postId} mutation={UPVOTE_POST}>
-                    {(upvotePost, { loading }) => (
-                      <li>
-                        {`${title} ${votes} votes `}
-                        {upvoteEnabled && (
-                          <button
-                            disabled={loading}
-                            onClick={() =>
-                              upvotePost({ variables: { postId } })
-                            }
-                          >
-                            Upvote
-                          </button>
-                        )}
-                      </li>
-                    )}
+                    {(upvotePost, { loading, error }) => {
+                      return (
+                        <li>
+                          {`${title} ${votes} votes `}
+                          {upvoteEnabled && (
+                            <button
+                              disabled={loading}
+                              onClick={() =>
+                                upvotePost({ variables: { postId } })
+                              }
+                            >
+                              Upvote
+                            </button>
+                          )}
+                          {error &&
+                            error.graphQLErrors && (
+                              <span style={{ color: 'red' }}>
+                                {error.graphQLErrors
+                                  .map(error => error.message)
+                                  .join(', ')}
+                              </span>
+                            )}
+                        </li>
+                      );
+                    }}
                   </Mutation>
                 ))}
               </ul>

--- a/examples/apollo/components/__fixtures__/Author/mock-graphql-errors.js
+++ b/examples/apollo/components/__fixtures__/Author/mock-graphql-errors.js
@@ -1,0 +1,46 @@
+import Author from '../../Author';
+
+export default {
+  component: Author,
+
+  props: {
+    authorId: 123,
+    upvoteEnabled: true
+  },
+  apollo: {
+    PostsForAuthor: {
+      resolveWith: {
+        author: {
+          __typename: 'Author',
+          id: 123,
+          firstName: 'Ovidiu',
+          posts: [
+            {
+              __typename: 'Post',
+              id: 456,
+              title: 'Testing React Components',
+              votes: 1234
+            },
+            { __typename: 'Post', id: 789, title: 'When to assert?', votes: 56 }
+          ]
+        }
+      }
+    },
+    UpvotePost: {
+      resolveWith: {
+        data: {
+          upvotePost: null
+        },
+        errors: [
+          {
+            path: ['upvotePost'],
+            message: [
+              'This is an example of a graphQL error, e.g. "you have already upvoted this"'
+            ],
+            locations: [{ line: 1, column: 0 }]
+          }
+        ]
+      }
+    }
+  }
+};

--- a/packages/react-cosmos-apollo-proxy/src/fixtureLink.js
+++ b/packages/react-cosmos-apollo-proxy/src/fixtureLink.js
@@ -15,7 +15,12 @@ export function createFixtureLink({ apolloFixture, cache, fixture }) {
           data:
             typeof resolveWith === 'function'
               ? resolveWith({ cache, variables, fixture })
-              : resolveWith
+              : resolveWith.data
+                ? resolveWith.data
+                : resolveWith,
+          errors:
+            (typeof resolveWith !== 'function' && resolveWith.errors) ||
+            undefined
         });
 
         observer.complete();


### PR DESCRIPTION
Allows the following syntax (note resolveWith has data.errors):

```
export default {
  component: Author,
  props: {
    authorId: -1
  },
  apollo: {
    resolveWith: {
      data: {
        author: null
      },
      errors: [
        {
          path: ['author'],
          message: ['Author id -1 not found'],
          locations: [{ line: 1, column: 0 }]
        }
      ]
    }
  }
};
```

Please note I am not familiar with this proxy. The tests all pass but I'm not sure if I broke anything by accident.