### PR TITLE
Provide Router Props

### DIFF
--- a/README.md
+++ b/README.md
@@ -466,7 +466,7 @@ export default {
 };
 ```
 
-If your component needs props from the `Route` component (history, location, and match), you can enabled the `provideRouterProps` flag.
+If your component needs props from the `Route` component (history, location, and match), you can enable the `provideRouterProps` flag.
 
 ```js
 // __fixtures__/example.js

--- a/README.md
+++ b/README.md
@@ -466,6 +466,18 @@ export default {
 };
 ```
 
+If your component needs props from the `Route` component (history, location, and match), you can enabled the `provideRouterProps` flag.
+
+```js
+// __fixtures__/example.js
+export default {
+  component: MyComponent,
+  url: '/users/5',
+  route: '/users/:userId',
+  provideRouterProps: true
+};
+```
+
 Check out the [React Router example](examples/react-router) to see the proxy in action.
 
 #### React Apollo (GraphQL)

--- a/examples/react-router/components/ProvideRouterProps.js
+++ b/examples/react-router/components/ProvideRouterProps.js
@@ -1,0 +1,12 @@
+import React from 'react';
+
+export default ({ location, match, history }) => (
+  <div>
+    <div>Location:</div>
+    <pre>{JSON.stringify(location, null, 2)}</pre>
+    <div>Match:</div>
+    <pre>{JSON.stringify(match, null, 2)}</pre>
+    <div>History:</div>
+    <pre>{JSON.stringify(history, null, 2)}</pre>
+  </div>
+);

--- a/examples/react-router/components/__fixtures__/ProvideRouterProps/index.js
+++ b/examples/react-router/components/__fixtures__/ProvideRouterProps/index.js
@@ -1,0 +1,18 @@
+import ProvideRouterProps from '../../ProvideRouterProps';
+
+export default [
+  {
+    component: ProvideRouterProps,
+    name: 'enabled',
+    route: '/user/:userId',
+    url: '/user/5',
+    provideRouterProps: true
+  },
+  {
+    component: ProvideRouterProps,
+    name: 'disabled',
+    route: '/user/:userId',
+    url: '/user/5',
+    provideRouterProps: false
+  }
+];

--- a/packages/react-cosmos-router-proxy/src/__tests__/provide-router-props.js
+++ b/packages/react-cosmos-router-proxy/src/__tests__/provide-router-props.js
@@ -7,7 +7,12 @@ import { createRouterProxy } from '..';
 // the end of the proxy chain. While it goes beyond unit testing, testing a
 // complete proxy chain provides a clearer picture than solely dissecting the
 // props that the tested proxy passes to the next.
-const Component = () => <span>__COMPONENT_MOCK__</span>;
+const Component = ({ location }) => {
+  if (!location) {
+    throw new Error('Expected props.location');
+  }
+  return <span>__COMPONENT_MOCK__</span>;
+};
 
 const NextProxy = props => {
   const { value: P, next } = props.nextProxy;
@@ -15,7 +20,7 @@ const NextProxy = props => {
   return <P {...props} nextProxy={next()} />;
 };
 
-const LastProxy = ({ fixture }) => <fixture.component />;
+const LastProxy = ({ fixture }) => <fixture.component {...fixture.props} />;
 
 // Vars populated from scratch before each test
 let onFixtureUpdate;

--- a/packages/react-cosmos-router-proxy/src/__tests__/provide-router-props.js
+++ b/packages/react-cosmos-router-proxy/src/__tests__/provide-router-props.js
@@ -1,6 +1,5 @@
 import React from 'react';
 import { mount } from 'enzyme';
-import { MemoryRouter, Route } from 'react-router';
 import { createRouterProxy } from '..';
 
 // The final responsibility of proxies is to render the user's component at

--- a/packages/react-cosmos-router-proxy/src/__tests__/provide-router-props.js
+++ b/packages/react-cosmos-router-proxy/src/__tests__/provide-router-props.js
@@ -1,0 +1,68 @@
+import React from 'react';
+import { mount } from 'enzyme';
+import { MemoryRouter, Route } from 'react-router';
+import { createRouterProxy } from '..';
+
+// The final responsibility of proxies is to render the user's component at
+// the end of the proxy chain. While it goes beyond unit testing, testing a
+// complete proxy chain provides a clearer picture than solely dissecting the
+// props that the tested proxy passes to the next.
+const Component = () => <span>__COMPONENT_MOCK__</span>;
+
+const NextProxy = props => {
+  const { value: P, next } = props.nextProxy;
+
+  return <P {...props} nextProxy={next()} />;
+};
+
+const LastProxy = ({ fixture }) => <fixture.component />;
+
+// Vars populated from scratch before each test
+let onFixtureUpdate;
+let wrapper;
+
+beforeEach(() => {
+  // Create Proxy with default options
+  const RouterProxy = createRouterProxy();
+
+  // Fixture updates from inner proxies need to bubble up to the root proxy
+  onFixtureUpdate = jest.fn();
+
+  // Mouting is more useful because it calls lifecycle methods and enables
+  // DOM interaction
+  wrapper = mount(
+    <RouterProxy
+      nextProxy={{
+        // Besides rendering the next proxy, we also need to ensure the 2nd
+        // next proxy is passed to the next proxy for further chaining. It
+        // might take a few reads to grasp this...
+        value: NextProxy,
+        next: () => ({
+          value: LastProxy,
+          next: () => {}
+        })
+      }}
+      fixture={{
+        component: Component,
+        // Except for some rare cases, the proxy needs to pass along the
+        // fixture without changing it
+        foo: 'bar',
+        // This tells RouterProxy to add MemoryRouter wrapper
+        url: '/route/foo',
+        // This tells RouterProxy to add Route wrapper
+        route: '/route/:param',
+        // This tells RouterProxy to inject routerProps
+        provideRouterProps: true
+      }}
+      onComponentRef={() => {}}
+      onFixtureUpdate={onFixtureUpdate}
+    />
+  );
+});
+
+test('renders component with router props', () => {
+  expect(wrapper.find(Component).props().location).toBeDefined();
+  expect(wrapper.find(Component).props().match).toBeDefined();
+  expect(wrapper.find(Component).props().history).toBeDefined();
+  expect(wrapper.text()).toEqual('__COMPONENT_MOCK__');
+});

--- a/packages/react-cosmos-router-proxy/src/__tests__/route.js
+++ b/packages/react-cosmos-router-proxy/src/__tests__/route.js
@@ -64,6 +64,9 @@ test('renders next proxy', () => {
 
 test('renders component', () => {
   expect(wrapper.text()).toEqual('__COMPONENT_MOCK__');
+  // We don't expect any props passed to the Component unless provideRouterProps
+  // is true. See provide-router-props.js test file.
+  expect(wrapper.find(Component).props()).toEqual({});
 });
 
 describe('next proxy props', () => {

--- a/packages/react-cosmos-router-proxy/src/index.js
+++ b/packages/react-cosmos-router-proxy/src/index.js
@@ -11,7 +11,7 @@ export function createRouterProxy() {
   const RouterProxy = (props: ProxyProps) => {
     const { nextProxy, fixture, onFixtureUpdate } = props;
     const { value: NextProxy, next } = nextProxy;
-    const { route, url, locationState } = fixture;
+    const { route, url, locationState, provideRouterProps } = fixture;
     const nextProxyEl = <NextProxy {...props} nextProxy={next()} />;
 
     if (locationState && !url) {
@@ -39,7 +39,23 @@ export function createRouterProxy() {
           onLocationStateChange={handleLocationStateChange}
         >
           {route ? (
-            <Route path={route} render={() => nextProxyEl} />
+            <Route
+              path={route}
+              render={routerProps => {
+                if (provideRouterProps) {
+                  const newProxyProps = {
+                    ...props,
+                    fixture: {
+                      ...props.fixture,
+                      props: { ...props.fixture.props, ...routerProps }
+                    }
+                  };
+                  return <NextProxy {...newProxyProps} nextProxy={next()} />;
+                } else {
+                  return nextProxyEl;
+                }
+              }}
+            />
           ) : (
             nextProxyEl
           )}

--- a/packages/react-cosmos-router-proxy/src/index.js
+++ b/packages/react-cosmos-router-proxy/src/index.js
@@ -51,9 +51,9 @@ export function createRouterProxy() {
                     }
                   };
                   return <NextProxy {...newProxyProps} nextProxy={next()} />;
-                } else {
-                  return nextProxyEl;
                 }
+
+                return nextProxyEl;
               }}
             />
           ) : (


### PR DESCRIPTION
Set `provideRouterProps: true` on a fixture to pass in `location`, `history`, and `match` from the `Route`.

Fixes https://github.com/react-cosmos/react-cosmos/issues/566