### PR TITLE
Fix babel-polyfill error in loader-entry.js

### DIFF
--- a/packages/react-cosmos/package.json
+++ b/packages/react-cosmos/package.json
@@ -5,7 +5,6 @@
   "repository": "https://github.com/react-cosmos/react-cosmos/tree/master/packages/react-cosmos",
   "license": "MIT",
   "dependencies": {
-    "babel-polyfill": "^6.26.0",
     "chokidar": "^2.0.4",
     "express": "^4.16.3",
     "fs-extra": "^6.0.1",

--- a/packages/react-cosmos/src/client/loader-entry.js
+++ b/packages/react-cosmos/src/client/loader-entry.js
@@ -1,19 +1,6 @@
 import './react-devtools-hook';
 import './react-error-overlay';
 import values from 'object.values';
-// import babel-polyfill only if it needed
-if (
-  (typeof window !== 'undefined' && !window._babelPolyfill) ||
-  (typeof global !== 'undefined' && !global._babelPolyfill)
-) {
-  import('babel-polyfill')
-    .then(polyfill => {
-      polyfill.open();
-    })
-    .catch(error => {
-      console.warn('Error open babel-polyfill');
-    });
-}
 
 if (!Object.values) {
   values.shim();

--- a/packages/react-cosmos/src/client/loader-entry.js
+++ b/packages/react-cosmos/src/client/loader-entry.js
@@ -1,7 +1,19 @@
 import './react-devtools-hook';
 import './react-error-overlay';
-import 'babel-polyfill';
 import values from 'object.values';
+// import babel-polyfill only if it needed
+if (
+  (typeof window !== 'undefined' && !window._babelPolyfill) ||
+  (typeof global !== 'undefined' && !global._babelPolyfill)
+) {
+  import('babel-polyfill')
+    .then(polyfill => {
+      polyfill.open();
+    })
+    .catch(error => {
+      console.warn('Error open babel-polyfill');
+    });
+}
 
 if (!Object.values) {
   values.shim();


### PR DESCRIPTION
Fix error `Error: only one instance of babel-polyfill is allowed` by adding conditional import.

Fixes #726