### PR TITLE
Adds support for spread in fixtures

### DIFF
--- a/packages/react-cosmos-voyager2/src/server/__tests__/esm/multi-spread/__fsmocks__/Bold.js
+++ b/packages/react-cosmos-voyager2/src/server/__tests__/esm/multi-spread/__fsmocks__/Bold.js
@@ -1,0 +1,9 @@
+// @flow
+
+import React, { Component } from 'react';
+
+export default class Bold extends Component<{ name: string }> {
+  render() {
+    return <strong>{this.props.name}</strong>;
+  }
+}

--- a/packages/react-cosmos-voyager2/src/server/__tests__/esm/multi-spread/__fsmocks__/fixtures.js
+++ b/packages/react-cosmos-voyager2/src/server/__tests__/esm/multi-spread/__fsmocks__/fixtures.js
@@ -1,0 +1,22 @@
+// @flow
+
+import Bold from './Bold';
+
+const baseFixture = {
+  component: Bold
+};
+
+export default [
+  {
+    ...baseFixture,
+    props: {
+      name: 'Alina'
+    }
+  },
+  {
+    ...baseFixture,
+    props: {
+      name: 'Sarah'
+    }
+  }
+];

--- a/packages/react-cosmos-voyager2/src/server/__tests__/esm/multi-spread/index.js
+++ b/packages/react-cosmos-voyager2/src/server/__tests__/esm/multi-spread/index.js
@@ -1,0 +1,30 @@
+// @flow
+
+import { join } from 'path';
+import { findFixtureFiles } from '../../../find-fixture-files';
+
+const { resolve } = require;
+
+describe('ES module / Multi fixture', () => {
+  let files;
+
+  beforeEach(async () => {
+    files = await findFixtureFiles({
+      rootPath: join(__dirname, '__fsmocks__')
+    });
+  });
+
+  it('has fixture path', () => {
+    expect(files[0].filePath).toBe(resolve('./__fsmocks__/fixtures'));
+  });
+
+  it('has component names', () => {
+    expect(files[0].components[0].name).toBe('Bold');
+    expect(files[0].components[1].name).toBe('Bold');
+  });
+
+  it('has component paths', () => {
+    expect(files[0].components[0].filePath).toBe(resolve('./__fsmocks__/Bold'));
+    expect(files[0].components[1].filePath).toBe(resolve('./__fsmocks__/Bold'));
+  });
+});

--- a/packages/react-cosmos-voyager2/src/server/extract-components-from-fixture-file.js
+++ b/packages/react-cosmos-voyager2/src/server/extract-components-from-fixture-file.js
@@ -113,9 +113,7 @@ export async function extractComponentsFromFixtureFile(
         }
 
         // $FlowFixMe
-        const compProp = fixtureBody.properties.find(
-          prop => prop.key.name === 'component'
-        );
+        const compProp = findThroughSpread(fixtureBody, vars);
         if (!compProp) {
           throw new Error('Fixture component property is missing');
         }
@@ -186,4 +184,24 @@ function getVarBodyByName(vars, varName: string): any | null {
   );
 
   return varBody;
+}
+
+function findThroughSpread(node, vars) {
+  if (!node) {
+    return;
+  }
+  for (const prop of node.properties) {
+    if (prop.key && prop.key.name === 'component') {
+      return prop;
+    }
+    if (prop.type === 'SpreadProperty') {
+      const searchedNode = findThroughSpread(
+        getVarBodyByName(vars, prop.argument.loc.identifierName),
+        vars
+      );
+      if (searchedNode) {
+        return searchedNode;
+      }
+    }
+  }
 }


### PR DESCRIPTION
Fixtures utilising ES6 spread would error out when trying to find the component and hence would not correctly appear in the same folder as others.

It bugged me that some of my fixtures would inexplicably go into a different folder, turns out this was why. Also the check for `prop.key.name === 'component'` would fail on a spread as `key` was undefined so it didn't matter if I had `component` defined after the spread, the spread would just break it all.

After matches what my directory structure is.
![spread detection copy](https://user-images.githubusercontent.com/1085899/43516856-c1426852-95c1-11e8-9f9e-a2762c8d1b53.png)