### PR TITLE
React router snapshot fix (Keys)

### DIFF
--- a/packages/react-cosmos-router-proxy/src/index.js
+++ b/packages/react-cosmos-router-proxy/src/index.js
@@ -33,7 +33,7 @@ export function createRouterProxy() {
     const location = buildLocation(url, locationState);
 
     return (
-      <MemoryRouter initialEntries={[location]}>
+      <MemoryRouter keyLength={0} initialEntries={[location]}>
         <LocationInterceptor
           onUrlChange={handleUrlChange}
           onLocationStateChange={handleLocationStateChange}


### PR DESCRIPTION
The keylength for the memoryrouter was not set thus the router generated new keys every run and breaking snapshots tests in the process. This simple prop addition fixes said issue.