### PR TITLE
fix(export): Log errors and fail command on errors

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -6,7 +6,3 @@ coverage:
       default:
         target: 90%
         threshold: 5%
-    patch:
-      default:
-        target: 80%
-        threshold: 25%

--- a/packages/react-cosmos/src/server/web/export.js
+++ b/packages/react-cosmos/src/server/web/export.js
@@ -31,6 +31,11 @@ const runWebpackCompiler = (webpack, config) =>
     compiler.run((err, stats) => {
       if (err) {
         reject(err);
+      } else if (stats.hasErrors()) {
+        const error = new Error('Errors occurred');
+        //$FlowFixMe
+        error.webpackErrors = stats.toJson().errors;
+        reject(error);
       } else {
         resolve(stats);
       }
@@ -87,8 +92,15 @@ export async function generateExport() {
         console.log(outputPath);
       },
       err => {
-        console.error('[Cosmos] Export Failed! See error below:');
-        console.error(err);
+        console.error('[Cosmos] Export Failed! See errors below:\n');
+        if (err.webpackErrors) {
+          err.webpackErrors.forEach(error => {
+            console.error(`${error}\n`);
+          });
+        } else {
+          console.error(err);
+        }
+        process.exit(1);
       }
     );
 }


### PR DESCRIPTION
Only errors coming from the error object from the `run` method were logged before. But there might be other kinds of errors coming from webpack and these need to be handled as well.

Fixes #834 

Example output:

![screen shot 2018-09-13 at 17 46 14](https://user-images.githubusercontent.com/382138/45499806-68180600-b77d-11e8-83e5-19fbfcb6d1e9.png)
