### PR TITLE
Extend httpProxy options to allow more options

### DIFF
--- a/README.md
+++ b/README.md
@@ -1107,6 +1107,7 @@ module.exports = {
   hot: false,
 
   // HTTP proxy specific requests to a different target
+  // For advanced usage see https://github.com/react-cosmos/react-cosmos/pull/875
   httpProxy: {
     context: '/api',
     target: 'http://localhost:4000/api'

--- a/packages/react-cosmos-flow/config.js
+++ b/packages/react-cosmos-flow/config.js
@@ -7,6 +7,8 @@ export type ExcludePatterns = ExcludePattern | Array<ExcludePattern>;
 type WebpackConfig = Object;
 type WebpackConfigOverride = (WebpackConfig, { env: string }) => WebpackConfig;
 
+export type PluginConfig = { [prop: string]: mixed };
+
 type BasicHttpProxyConfig = { context: string };
 type AdvancedHttpProxyConfig = { [contextKey: string]: string | {} };
 export type HttpProxyConfig = BasicHttpProxyConfig | AdvancedHttpProxyConfig;

--- a/packages/react-cosmos-flow/config.js
+++ b/packages/react-cosmos-flow/config.js
@@ -9,6 +9,14 @@ type WebpackConfigOverride = (WebpackConfig, { env: string }) => WebpackConfig;
 
 export type PluginConfig = { [prop: string]: mixed };
 
+type BasicHttpProxyConfig = { context: string };
+
+type AdvancedHttpProxyConfig = {
+  [context: string]: {}
+};
+
+type HttpProxyConfig = BasicHttpProxyConfig | AdvancedHttpProxyConfig;
+
 export type Config = {
   next: boolean,
   rootPath: string,
@@ -26,7 +34,7 @@ export type Config = {
   publicPath?: string,
   publicUrl: string,
   containerQuerySelector?: string,
-  httpProxy?: {| context: string, target: string |},
+  httpProxy?: HttpProxyConfig,
   watchDirs: Array<string>,
   modulesPath: string,
   plugin: PluginConfig,

--- a/packages/react-cosmos-flow/config.js
+++ b/packages/react-cosmos-flow/config.js
@@ -7,15 +7,9 @@ export type ExcludePatterns = ExcludePattern | Array<ExcludePattern>;
 type WebpackConfig = Object;
 type WebpackConfigOverride = (WebpackConfig, { env: string }) => WebpackConfig;
 
-export type PluginConfig = { [prop: string]: mixed };
-
 type BasicHttpProxyConfig = { context: string };
-
-type AdvancedHttpProxyConfig = {
-  [context: string]: {}
-};
-
-type HttpProxyConfig = BasicHttpProxyConfig | AdvancedHttpProxyConfig;
+type AdvancedHttpProxyConfig = { [contextKey: string]: string | {} };
+export type HttpProxyConfig = BasicHttpProxyConfig | AdvancedHttpProxyConfig;
 
 export type Config = {
   next: boolean,

--- a/packages/react-cosmos/src/server/shared/__tests__/http-proxy.js
+++ b/packages/react-cosmos/src/server/shared/__tests__/http-proxy.js
@@ -1,0 +1,82 @@
+import httpProxyMiddleware from 'http-proxy-middleware';
+
+import { setupHttpProxy } from '../http-proxy';
+
+jest.mock('http-proxy-middleware');
+
+describe('setup http proxy', () => {
+  beforeEach(() => {
+    httpProxyMiddleware.mockReset();
+  });
+
+  it('with basic configuration', () => {
+    const app = {
+      use: jest.fn()
+    };
+
+    const httpProxyConfig = {
+      context: '/api',
+      target: 'https://example.com',
+      otherValue: {
+        test: 'value'
+      }
+    };
+
+    httpProxyMiddleware.mockReturnValueOnce('__MOCKED_MIDDLEWARE__');
+
+    setupHttpProxy(app, httpProxyConfig);
+
+    expect(app.use).toHaveBeenCalledWith('/api', '__MOCKED_MIDDLEWARE__');
+    expect(httpProxyMiddleware).toHaveBeenCalledWith({
+      target: 'https://example.com',
+      otherValue: {
+        test: 'value'
+      }
+    });
+  });
+
+  it('with advanced configuration', () => {
+    const app = {
+      use: jest.fn()
+    };
+
+    const httpProxyConfig = {
+      '/api': {
+        target: 'https://example-api.com',
+        apiStuff: {
+          api: 'value'
+        }
+      },
+      '/assets': {
+        target: 'https://example-assets.com',
+        assetsStuff: {
+          asset: 'value'
+        }
+      }
+    };
+
+    httpProxyMiddleware.mockReturnValueOnce('__MOCKED_API_MIDDLEWARE__');
+    httpProxyMiddleware.mockReturnValueOnce('__MOCKED_ASSETS_MIDDLEWARE__');
+
+    setupHttpProxy(app, httpProxyConfig);
+
+    expect(app.use).toHaveBeenCalledWith('/api', '__MOCKED_API_MIDDLEWARE__');
+    expect(httpProxyMiddleware).toHaveBeenCalledWith({
+      target: 'https://example-api.com',
+      apiStuff: {
+        api: 'value'
+      }
+    });
+
+    expect(app.use).toHaveBeenCalledWith(
+      '/assets',
+      '__MOCKED_ASSETS_MIDDLEWARE__'
+    );
+    expect(httpProxyMiddleware).toHaveBeenCalledWith({
+      target: 'https://example-assets.com',
+      assetsStuff: {
+        asset: 'value'
+      }
+    });
+  });
+});

--- a/packages/react-cosmos/src/server/shared/http-proxy.js
+++ b/packages/react-cosmos/src/server/shared/http-proxy.js
@@ -1,0 +1,19 @@
+// @flow
+
+import httpProxyMiddleware from 'http-proxy-middleware';
+import type { HttpProxyConfig } from 'react-cosmos-flow/config';
+
+export function setupHttpProxy(
+  app: express$Application,
+  httpProxy: HttpProxyConfig
+) {
+  const { context, ...options } = httpProxy;
+  if (typeof context === 'string') {
+    app.use(context, httpProxyMiddleware(options));
+  } else {
+    Object.keys(httpProxy).forEach(contextKey => {
+      const options = httpProxy[contextKey];
+      app.use(contextKey, httpProxyMiddleware(options));
+    });
+  }
+}

--- a/packages/react-cosmos/src/server/shared/server.js
+++ b/packages/react-cosmos/src/server/shared/server.js
@@ -8,7 +8,7 @@ import httpProxyMiddleware from 'http-proxy-middleware';
 import launchEditor from 'react-dev-utils/launchEditor';
 import { getPlaygroundHtml, getPlaygroundHtmlNext } from './playground-html';
 
-import type { Config } from 'react-cosmos-flow/config';
+import type { Config, HttpProxyConfig } from 'react-cosmos-flow/config';
 import type { PlaygroundOpts } from 'react-cosmos-flow/playground';
 
 export function createServerApp({
@@ -22,15 +22,7 @@ export function createServerApp({
   const app = express();
 
   if (httpProxy) {
-    if (httpProxy.context) {
-      const { context, ...options } = httpProxy;
-      app.use(context, httpProxyMiddleware(options));
-    } else {
-      Object.keys(httpProxy).forEach(context => {
-        const options = httpProxy[context];
-        app.use(context, httpProxyMiddleware(options));
-      });
-    }
+    setupHttpProxy(app, httpProxy);
   }
 
   const playgroundHtml =
@@ -102,6 +94,18 @@ export function attachStackFrameEditorLauncher(app: express$Application) {
       res.end();
     }
   );
+}
+
+function setupHttpProxy(app: express$Application, httpProxy: HttpProxyConfig) {
+  if (httpProxy.context) {
+    const { context, ...options } = httpProxy;
+    app.use(context, httpProxyMiddleware(options));
+  } else {
+    Object.keys(httpProxy).forEach(contextKey => {
+      const options = httpProxy[contextKey];
+      app.use(contextKey, httpProxyMiddleware(options));
+    });
+  }
 }
 
 export function getRootUrl(publicUrl: string) {

--- a/packages/react-cosmos/src/server/shared/server.js
+++ b/packages/react-cosmos/src/server/shared/server.js
@@ -97,8 +97,8 @@ export function attachStackFrameEditorLauncher(app: express$Application) {
 }
 
 function setupHttpProxy(app: express$Application, httpProxy: HttpProxyConfig) {
-  if (httpProxy.context) {
-    const { context, ...options } = httpProxy;
+  const { context, ...options } = httpProxy;
+  if (typeof context === 'string') {
     app.use(context, httpProxyMiddleware(options));
   } else {
     Object.keys(httpProxy).forEach(contextKey => {

--- a/packages/react-cosmos/src/server/shared/server.js
+++ b/packages/react-cosmos/src/server/shared/server.js
@@ -7,8 +7,9 @@ import express from 'express';
 import httpProxyMiddleware from 'http-proxy-middleware';
 import launchEditor from 'react-dev-utils/launchEditor';
 import { getPlaygroundHtml, getPlaygroundHtmlNext } from './playground-html';
+import { setupHttpProxy } from './http-proxy';
 
-import type { Config, HttpProxyConfig } from 'react-cosmos-flow/config';
+import type { Config } from 'react-cosmos-flow/config';
 import type { PlaygroundOpts } from 'react-cosmos-flow/playground';
 
 export function createServerApp({
@@ -94,18 +95,6 @@ export function attachStackFrameEditorLauncher(app: express$Application) {
       res.end();
     }
   );
-}
-
-function setupHttpProxy(app: express$Application, httpProxy: HttpProxyConfig) {
-  const { context, ...options } = httpProxy;
-  if (typeof context === 'string') {
-    app.use(context, httpProxyMiddleware(options));
-  } else {
-    Object.keys(httpProxy).forEach(contextKey => {
-      const options = httpProxy[contextKey];
-      app.use(contextKey, httpProxyMiddleware(options));
-    });
-  }
 }
 
 export function getRootUrl(publicUrl: string) {

--- a/packages/react-cosmos/src/server/shared/server.js
+++ b/packages/react-cosmos/src/server/shared/server.js
@@ -22,8 +22,15 @@ export function createServerApp({
   const app = express();
 
   if (httpProxy) {
-    const { context, target } = httpProxy;
-    app.use(context, httpProxyMiddleware(target));
+    if (httpProxy.context) {
+      const { context, ...options } = httpProxy;
+      app.use(context, httpProxyMiddleware(options));
+    } else {
+      Object.keys(httpProxy).forEach(context => {
+        const options = httpProxy[context];
+        app.use(context, httpProxyMiddleware(options));
+      });
+    }
   }
 
   const playgroundHtml =

--- a/packages/react-cosmos/src/server/shared/server.js
+++ b/packages/react-cosmos/src/server/shared/server.js
@@ -4,7 +4,6 @@ import { join, relative } from 'path';
 import { createServer as createHttpServer } from 'http';
 import promisify from 'util.promisify';
 import express from 'express';
-import httpProxyMiddleware from 'http-proxy-middleware';
 import launchEditor from 'react-dev-utils/launchEditor';
 import { getPlaygroundHtml, getPlaygroundHtmlNext } from './playground-html';
 import { setupHttpProxy } from './http-proxy';


### PR DESCRIPTION
[http-proxy-middleware](https://github.com/chimurai/http-proxy-middleware) has a lot of other options available than just `target`

This PR is to extend the existing method of configuring the proxy to allow those other options to be used.

It also allows you specify multiple proxies against different contexts in the similar way the [webpack-dev-server proxy](https://webpack.js.org/configuration/dev-server/#devserver-proxy) does