### PR TITLE
Ignore HOC names when sorting components

### DIFF
--- a/packages/react-cosmos-voyager2/src/client/get-components.js
+++ b/packages/react-cosmos-voyager2/src/client/get-components.js
@@ -152,7 +152,7 @@ export function getComponents({
     });
   }
 
-  return sortBy(components, getObjectPath);
+  return sortBy(components, sortComponentsBy);
 }
 
 function getFileNameFromPath(filePath: string) {
@@ -215,4 +215,14 @@ function warnAboutIncompatFixtures(
 
 function getObjectPath(obj: { name: string, namespace: string }): string {
   return obj.namespace ? `${obj.namespace}/${obj.name}` : obj.name;
+}
+
+function sortComponentsBy(obj: { name: string, namespace: string }): string {
+  // remove all trailing ')', split string by '(' and get the first part.
+  // This gives the component name removed of all potential HOC names.
+  const componentName = obj.name
+    .replace(/\)/g, '')
+    .split('(')
+    .pop();
+  return obj.namespace ? `${obj.namespace}/${componentName}` : componentName;
 }

--- a/packages/react-cosmos-voyager2/src/client/get-components.js
+++ b/packages/react-cosmos-voyager2/src/client/get-components.js
@@ -152,7 +152,7 @@ export function getComponents({
     });
   }
 
-  return sortBy(components, sortComponentsBy);
+  return sortBy(components, stripHocNamesFromComponentName);
 }
 
 function getFileNameFromPath(filePath: string) {
@@ -217,12 +217,13 @@ function getObjectPath(obj: { name: string, namespace: string }): string {
   return obj.namespace ? `${obj.namespace}/${obj.name}` : obj.name;
 }
 
-function sortComponentsBy(obj: { name: string, namespace: string }): string {
-  // remove all trailing ')', split string by '(' and get the first part.
-  // This gives the component name removed of all potential HOC names.
-  const componentName = obj.name
-    .replace(/\)/g, '')
-    .split('(')
-    .pop();
+function stripHocNamesFromComponentName(obj: {
+  name: string,
+  namespace: string
+}): string {
+  // withRouter(connect(MyComponent)) -> MyComponent
+  // connect(MyComponent)) -> MyComponent
+  // MyComponent -> MyComponent
+  const componentName = obj.name.replace(/^(.*\()?(.+?)\)*$/, '$2');
   return obj.namespace ? `${obj.namespace}/${componentName}` : componentName;
 }


### PR DESCRIPTION
Hey, awesome project!

I want to get your thoughts on this before writing more code/tests.

## The issue
![image](https://user-images.githubusercontent.com/2373958/46871925-f8a43d80-ce32-11e8-9aed-6c4ade2a76ca.png)

These components should semantically, stand side-by-side and be sorted under "T". But a few of them are connected components (the hoc from react-redux) and that pulls them to be sorted under "C".

## This PR will
skips all HOC names when components are sorted.

Another approach could be to allow users to provide a `sortComponentsBy: () =>{}` function through `cosmos.config.js`.