### PR TITLE
Add runtimeConfig and preferCollapsedFixtures

### DIFF
--- a/packages/react-cosmos-flow/config.js
+++ b/packages/react-cosmos-flow/config.js
@@ -7,6 +7,8 @@ export type ExcludePatterns = ExcludePattern | Array<ExcludePattern>;
 type WebpackConfig = Object;
 type WebpackConfigOverride = (WebpackConfig, { env: string }) => WebpackConfig;
 
+type RuntimeConfig = { preferCollapsedFixtures: boolean };
+
 export type PluginConfig = { [prop: string]: mixed };
 
 export type Config = {
@@ -30,6 +32,7 @@ export type Config = {
   watchDirs: Array<string>,
   modulesPath: string,
   plugin: PluginConfig,
+  runtimeOptions?: RuntimeConfig,
   // Deprecated
   proxies?: Array<string>,
   componentPaths: Array<string>,

--- a/packages/react-cosmos-playground/cosmos.config.js
+++ b/packages/react-cosmos-playground/cosmos.config.js
@@ -1,5 +1,8 @@
 module.exports = {
   globalImports: ['src/utils/global.less', 'src/register-plugins'],
   exclude: [/_shared/],
-  port: 8090
+  port: 8090,
+  runtimeConfig: {
+    preferCollapsedFixtures: true
+  }
 };

--- a/packages/react-cosmos-playground/src/components/FixtureList/data-mapper.js
+++ b/packages/react-cosmos-playground/src/components/FixtureList/data-mapper.js
@@ -4,10 +4,10 @@ import sortBy from 'lodash.sortby';
 
 const NODE_ORDER_BY_TYPE = ['directory', 'component'];
 
-function getExandedValue(savedExpansionState, path) {
+function getExandedValue(savedExpansionState, path, defaultValue = true) {
   return Object.prototype.hasOwnProperty.call(savedExpansionState, path)
     ? savedExpansionState[path]
-    : true;
+    : defaultValue;
 }
 
 function parseFixtureArray(componentName, fixtureArray, savedExpansionState) {
@@ -84,7 +84,12 @@ const generateDisplayData = name => {
   };
 };
 
-const dataObjectToNestedArray = (base, savedExpansionState, path = '') => {
+const dataObjectToNestedArray = (
+  base,
+  savedExpansionState,
+  preferCollapsedFixtures,
+  path = ''
+) => {
   const returnChildren = [];
   for (const key in base) {
     if (typeof base[key] === 'object') {
@@ -92,6 +97,7 @@ const dataObjectToNestedArray = (base, savedExpansionState, path = '') => {
       const children = dataObjectToNestedArray(
         base[key],
         savedExpansionState,
+        preferCollapsedFixtures,
         newPath
       );
       const isDirectory = some(
@@ -107,7 +113,11 @@ const dataObjectToNestedArray = (base, savedExpansionState, path = '') => {
       returnChildren.push({
         name: key,
         path: newPath,
-        expanded: getExandedValue(savedExpansionState, newPath),
+        expanded: getExandedValue(
+          savedExpansionState,
+          newPath,
+          isDirectory ? true : !preferCollapsedFixtures
+        ),
         type: isDirectory ? 'directory' : 'component',
         displayData,
         children
@@ -123,7 +133,11 @@ const dataObjectToNestedArray = (base, savedExpansionState, path = '') => {
   return sortBy(returnChildren, node => NODE_ORDER_BY_TYPE.indexOf(node.type));
 };
 
-const fixturesToTreeData = (fixtures, savedExpansionState) => {
+const fixturesToTreeData = (
+  fixtures,
+  savedExpansionState,
+  preferCollapsedFixtures
+) => {
   const components = Object.keys(fixtures);
   const data = {};
 
@@ -133,7 +147,11 @@ const fixturesToTreeData = (fixtures, savedExpansionState) => {
     set(data, pathArray, fixturesAtPath);
   });
 
-  return dataObjectToNestedArray(data, savedExpansionState);
+  return dataObjectToNestedArray(
+    data,
+    savedExpansionState,
+    preferCollapsedFixtures
+  );
 };
 
 export default fixturesToTreeData;

--- a/packages/react-cosmos-playground/src/components/FixtureList/index.js
+++ b/packages/react-cosmos-playground/src/components/FixtureList/index.js
@@ -31,12 +31,19 @@ export default class FixtureList extends Component {
     window.addEventListener('keydown', this.onWindowKey);
 
     const savedExpansionState = await getSavedExpansionState(projectKey);
+    const preferCollapsedFixtures =
+      this.props.options.runtimeConfig &&
+      this.props.options.runtimeConfig.preferCollapsedFixtures;
 
     if (this.unmounted === true) {
       return;
     }
 
-    const fixtureTree = fixturesToTreeData(fixtures, savedExpansionState);
+    const fixtureTree = fixturesToTreeData(
+      fixtures,
+      savedExpansionState,
+      preferCollapsedFixtures
+    );
     pruneUnusedExpansionState(projectKey, savedExpansionState, fixtureTree);
     this.setState({ fixtureTree });
   }

--- a/packages/react-cosmos/src/server/shared/server.js
+++ b/packages/react-cosmos/src/server/shared/server.js
@@ -18,7 +18,7 @@ export function createServerApp({
   cosmosConfig: Config,
   playgroundOpts: PlaygroundOpts
 }) {
-  const { next, httpProxy } = cosmosConfig;
+  const { next, httpProxy, runtimeConfig } = cosmosConfig;
   const app = express();
 
   if (httpProxy) {
@@ -30,7 +30,7 @@ export function createServerApp({
     // TODO: Support JSX fixtures for any platform
     next && playgroundOpts.platform === 'web'
       ? getPlaygroundHtmlNext({ rendererUrl: playgroundOpts.loaderUri })
-      : getPlaygroundHtml(playgroundOpts);
+      : getPlaygroundHtml({ runtimeConfig, ...playgroundOpts });
   app.get('/', (req: express$Request, res: express$Response) => {
     res.send(playgroundHtml);
   });


### PR DESCRIPTION
Hey, me again with an idea as a pull request. 
This is very much just a spike to get some thoughts on.
If this is desired we can discuss how to do this in a good way.

## This PR will
- add the optional `runtimeConfig` key to `cosmos.config.js`. 
  - The `runtimeConfig` key will be passed to the `mountPlayground` and therefor be accessible in the playground.
  - The idea behind this config is to allow customizations to the runtime. For example `runtimeConfig.preferCollapsedFixtures`
- Add `runtimeConfig.preferCollapsedFixtures`. If true it will cause all fixtures that do not have a saved expansion state to be collapsed by default.
  -  ![image](https://user-images.githubusercontent.com/2373958/46875960-5fc6ef80-ce3d-11e8-9c4b-c40ca80fc7cc.png)
  - partially discussed in https://github.com/react-cosmos/react-cosmos/issues/251

"Hide all/ Show all" buttons + saved expansions state, would achieve the same thing more or less and I think thats been discussed in the past. If thats the plan, feel free to close this PR.