### PR TITLE
Enable Apollo proxy cache configuration for mocked fixture

### DIFF
--- a/packages/react-cosmos-apollo-proxy/src/__tests__/client.js
+++ b/packages/react-cosmos-apollo-proxy/src/__tests__/client.js
@@ -123,19 +123,40 @@ describe('proxy configured with a client', () => {
 
   beforeEach(() => {
     clientOptions = {
-      cache: new InMemoryCache(),
+      cache: new InMemoryCache({
+        addTypename: false,
+        dataIdFromObject: object => object.key || null
+      }),
       link: new HttpLink({ uri: 'https://xyz' })
     };
-
-    setupTestWrapper({ proxyConfig: { clientOptions } });
   });
 
   it('uses the clientOptions passed in the config', () => {
+    setupTestWrapper({ proxyConfig: { clientOptions } });
+
     expect(wrapper.instance().client.cache).toBe(clientOptions.cache);
   });
 
   it('connects to the Apollo DevTools', () => {
+    setupTestWrapper({ proxyConfig: { clientOptions } });
+
     expect(parent.__APOLLO_CLIENT__).toBe(wrapper.instance().client);
+  });
+
+  it('uses the clientOptions cache config for mocked fixture', () => {
+    setupTestWrapper({
+      proxyConfig: { clientOptions },
+      fixture: {
+        ...sampleFixture,
+        apollo: {
+          resolveWith
+        }
+      }
+    });
+
+    expect(wrapper.instance().client.cache.config).toEqual(
+      clientOptions.cache.config
+    );
   });
 });
 

--- a/packages/react-cosmos-apollo-proxy/src/fixtureLink.js
+++ b/packages/react-cosmos-apollo-proxy/src/fixtureLink.js
@@ -34,34 +34,34 @@ export function createFixtureLink({ apolloFixture, cache, fixture }) {
 
         if (failWith) {
           observer.error(failWith);
-        }
-
-        // never resolve query, endless loading state
-        if (latency === -1) {
-          return;
-        }
-
-        setTimeout(() => {
-          if (typeof resolveWith === 'function') {
-            resolveFunctionOrPromise(
-              resolveWith({
-                cache,
-                variables,
-                fixture,
-                operationName,
-                ...others
-              }),
-              observer
-            );
-          } else {
-            observer.next({
-              data: resolveWith.data ? resolveWith.data : resolveWith,
-              errors: resolveWith.errors
-            });
-
-            observer.complete();
+        } else {
+          // never resolve query, endless loading state
+          if (latency === -1) {
+            return;
           }
-        }, latency * 1000);
+
+          setTimeout(() => {
+            if (typeof resolveWith === 'function') {
+              resolveFunctionOrPromise(
+                resolveWith({
+                  cache,
+                  variables,
+                  fixture,
+                  operationName,
+                  ...others
+                }),
+                observer
+              );
+            } else {
+              observer.next({
+                data: resolveWith.data ? resolveWith.data : resolveWith,
+                errors: resolveWith.errors
+              });
+
+              observer.complete();
+            }
+          }, latency * 1000);
+        }
       })
   );
 }

--- a/packages/react-cosmos-apollo-proxy/src/index.js
+++ b/packages/react-cosmos-apollo-proxy/src/index.js
@@ -42,21 +42,21 @@ Read more at: https://github.com/react-cosmos/react-cosmos#react-apollo-graphql.
         mockKeys.find(key => fixtureApolloKeys.includes(key))
       );
 
-      const cache = new InMemoryCache();
-
       let options = clientOptions || {
-        cache,
+        cache: new InMemoryCache(),
         link: new HttpLink({ uri: endpoint })
       };
 
       if (isMockedFixture) {
+        const fixtureCache = new InMemoryCache(options.cache.config);
+
         options = {
           ...options,
           // ensure that the cache is not persisted between mocked fixtures
-          cache,
+          cache: fixtureCache,
           link: createFixtureLink({
             apolloFixture,
-            cache: options.cache,
+            cache: fixtureCache,
             fixture: this.props.fixture
           })
         };


### PR DESCRIPTION
:wave: , hello there!

This PR:
- adds support for Apollo `InMemoryCache` configuration (see https://www.apollographql.com/docs/react/advanced/caching.html#configuration), which is dank useful;
- fixes a bug to avoid execution of `failWith` & `resolveWith` (fixes fixtures `mock-simple-error` and `real-error`)