### PR TITLE
fixed peerDependencies

### DIFF
--- a/example/package.json
+++ b/example/package.json
@@ -8,7 +8,10 @@
     "start": "cosmos"
   },
   "dependencies": {
-    "react-cosmos": "^5.0.0-alpha.15"
+    "react": "^16.0.0",
+    "react-cosmos": "^5.0.0-alpha.15",
+    "react-dom": "^16.0.0",
+    "webpack": "^4.0.0"
   },
   "devDependencies": {
     "html-webpack-plugin": "^3.2.0"

--- a/packages/react-cosmos-fixture/package.json
+++ b/packages/react-cosmos-fixture/package.json
@@ -11,5 +11,9 @@
     "react-cosmos-shared2": "^5.0.0-alpha.14",
     "react-is": "^16.8.6",
     "socket.io-client": "^2.2.0"
+  },
+  "peerDependencies": {
+    "react": "^16.0.0",
+    "react-dom": "^16.0.0"
   }
 }

--- a/packages/react-cosmos-playground2/package.json
+++ b/packages/react-cosmos-playground2/package.json
@@ -16,5 +16,8 @@
     "react-plugin": "^2.0.0-alpha.6",
     "socket.io-client": "^2.2.0",
     "styled-components": "^4.3.2"
+  },
+  "peerDependencies": {
+    "webpack": "^4.0.0"
   }
 }

--- a/packages/react-cosmos-shared2/package.json
+++ b/packages/react-cosmos-shared2/package.json
@@ -8,5 +8,9 @@
     "lodash": "^4.17.11",
     "react-element-to-jsx-string": "^14.0.2",
     "react-is": "^16.8.6"
+  },
+  "peerDependencies": {
+    "react": "^16.0.0",
+    "react-dom": "^16.0.0"
   }
 }

--- a/packages/react-cosmos/package.json
+++ b/packages/react-cosmos/package.json
@@ -30,6 +30,11 @@
     "webpack-dev-middleware": "^3.7.0",
     "yargs": "^13.2.4"
   },
+  "peerDependencies": {
+    "react": "^16.0.0",
+    "react-dom": "^16.0.0",
+    "webpack": "^4.0.0"
+  },
   "bin": {
     "cosmos": "./bin/cosmos.js",
     "cosmos-export": "./bin/cosmos-export.js",


### PR DESCRIPTION
This fix will allow for this lib to be used with yarn berry and yarn pnp without having to manually hack into the yarn.lock file.

when forking the inicial branch, upgrading to yarn berry, i had the warnings at end of post.
These warnings cause errors when using cosmos on my packages with PNP.
I have a branch on my fork with this library on yarn2, but I haven't tested it.

With these fixes the warnings go away(the ones related to this lib). This is related to #946 so hopefully we can move on that issue.


```
➤ YN0000: ┌ Resolution step
➤ YN0002: │ @typescript-eslint/parser@npm:1.11.0 doesn't provide typescript@* requested by @typescript-eslint/experimental-utils@npm:1.11.0
➤ YN0002: │ react-cosmos-shared2@workspace:packages/react-cosmos-shared2 doesn't provide react@^0.14.8 || ^15.0.1 || ^16.0.0 requested by react-element-to-jsx-string@npm:14.0.2
➤ YN0002: │ react-cosmos-shared2@workspace:packages/react-cosmos-shared2 doesn't provide react-dom@^0.14.8 || ^15.0.1 || ^16.0.0 requested by react-element-to-jsx-string@npm:14.0.2
➤ YN0002: │ react-cosmos-playground2@workspace:packages/react-cosmos-playground2 doesn't provide webpack@^1.0.0 || ^2.0.0 || ^3.0.0 || ^4.0.0 requested by html-webpack-plugin@npm:3.2.0
➤ YN0002: │ react-cosmos@workspace:packages/react-cosmos doesn't provide webpack@^4.0.0 requested by webpack-dev-middleware@npm:3.7.0
➤ YN0002: │ react-cosmos-example@workspace:example doesn't provide webpack@^1.0.0 || ^2.0.0 || ^3.0.0 || ^4.0.0 requested by html-webpack-plugin@npm:3.2.0
➤ YN0000: └ Completed in 0.19s
➤ YN0000: ┌ Fetch step
➤ YN0000: └ Completed in 1.11s
➤ YN0000: ┌ Link step
➤ YN0000: └ Completed in 4.05s
➤ YN0000: Done with warnings in 5.46s
```