### PR TITLE
Improve fixture search UX

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -5,6 +5,6 @@ coverage:
     project:
       default:
         target: auto
-        threshold: 1%
+        threshold: 3%
         base: auto
     patch: no

--- a/packages/react-cosmos-playground2/src/plugins/FixtureSearch/FixtureSearchHeader.tsx
+++ b/packages/react-cosmos-playground2/src/plugins/FixtureSearch/FixtureSearchHeader.tsx
@@ -18,7 +18,7 @@ export function FixtureSearchHeader({ onOpen }: Props) {
     }
     window.addEventListener('keydown', handleWindowKeyDown);
     return () => window.removeEventListener('keydown', handleWindowKeyDown);
-  });
+  }, [onOpen]);
 
   return (
     <Container>

--- a/packages/react-cosmos-playground2/src/plugins/FixtureSearch/FixtureSearchOverlay.fixture.tsx
+++ b/packages/react-cosmos-playground2/src/plugins/FixtureSearch/FixtureSearchOverlay.fixture.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { FixtureId } from 'react-cosmos-shared2/renderer';
 import { FixtureSearchOverlay } from './FixtureSearchOverlay';
 
 const fixtures = {
@@ -21,12 +22,26 @@ const fixtures = {
   'src/shared/ui/valueInputTree/index.fixture.tsx': null
 };
 
-export default (
-  <FixtureSearchOverlay
-    fixturesDir="__fixtures__"
-    fixtureFileSuffix="fixture"
-    fixtures={fixtures}
-    onClose={() => console.log('Close fixture search overlay')}
-    onSelect={fixtureId => console.log('Select fixture', fixtureId)}
-  />
-);
+export default {
+  'from scratch': createFixtureSearchOverlay(),
+
+  'fixture selected': createFixtureSearchOverlay({
+    path: 'src/plugins/Notifications/index.fixture.tsx',
+    name: 'multiple'
+  })
+};
+
+function createFixtureSearchOverlay(fixtureId: null | FixtureId = null) {
+  return (
+    <FixtureSearchOverlay
+      fixturesDir="__fixtures__"
+      fixtureFileSuffix="fixture"
+      fixtures={fixtures}
+      selectedFixtureId={fixtureId}
+      onClose={() => console.log('Close fixture search overlay')}
+      onSelect={selectedFixtureId =>
+        console.log('Select fixture', selectedFixtureId)
+      }
+    />
+  );
+}

--- a/packages/react-cosmos-playground2/src/plugins/FixtureSearch/FixtureSearchOverlay.fixture.tsx
+++ b/packages/react-cosmos-playground2/src/plugins/FixtureSearch/FixtureSearchOverlay.fixture.tsx
@@ -23,7 +23,7 @@ const fixtures = {
 };
 
 export default {
-  'from scratch': createFixtureSearchOverlay(),
+  'no fixure selected': createFixtureSearchOverlay(),
 
   'fixture selected': createFixtureSearchOverlay({
     path: 'src/plugins/Notifications/index.fixture.tsx',

--- a/packages/react-cosmos-playground2/src/plugins/FixtureSearch/FixtureSearchOverlay.tsx
+++ b/packages/react-cosmos-playground2/src/plugins/FixtureSearch/FixtureSearchOverlay.tsx
@@ -1,5 +1,6 @@
 import { filter } from 'fuzzaldrin-plus';
 import React from 'react';
+import { isEqual } from 'lodash';
 import { FixtureId, FixtureNamesByPath } from 'react-cosmos-shared2/renderer';
 import styled from 'styled-components';
 import { createFixtureTree } from '../../shared/fixtureTree';
@@ -18,6 +19,7 @@ type Props = {
   fixturesDir: string;
   fixtureFileSuffix: string;
   fixtures: FixtureNamesByPath;
+  selectedFixtureId: null | FixtureId;
   onClose: () => unknown;
   onSelect: (fixtureId: FixtureId) => unknown;
 };
@@ -28,6 +30,7 @@ export function FixtureSearchOverlay({
   fixturesDir,
   fixtureFileSuffix,
   fixtures,
+  selectedFixtureId,
   onClose,
   onSelect
 }: Props) {
@@ -49,7 +52,12 @@ export function FixtureSearchOverlay({
 
   const [activeFixturePath, setActiveFixturePath] = React.useState<
     ActiveFixturePath
-  >(getFirstFixturePath(matchingFixturePaths));
+  >(() => {
+    return (
+      (selectedFixtureId && getFixturePath(fixtureIds, selectedFixtureId)) ||
+      getFirstFixturePath(matchingFixturePaths)
+    );
+  });
 
   const onInputChange = React.useCallback(
     (e: React.ChangeEvent<HTMLInputElement>) => {
@@ -204,6 +212,13 @@ export function FixtureSearchOverlay({
         </ResultsViewport>
       </Content>
     </Overlay>
+  );
+}
+
+function getFixturePath(fixtureIds: FixtureIdsByPath, fixtureId: FixtureId) {
+  const fixturePaths = Object.keys(fixtureIds);
+  return fixturePaths.find(fixturePath =>
+    isEqual(fixtureIds[fixturePath], fixtureId)
   );
 }
 

--- a/packages/react-cosmos-playground2/src/plugins/FixtureSearch/FixtureSearchOverlay.tsx
+++ b/packages/react-cosmos-playground2/src/plugins/FixtureSearch/FixtureSearchOverlay.tsx
@@ -21,7 +21,7 @@ type Props = {
   fixtures: FixtureNamesByPath;
   selectedFixtureId: null | FixtureId;
   onClose: () => unknown;
-  onSelect: (fixtureId: FixtureId) => unknown;
+  onSelect: (fixtureId: FixtureId, revealFixture: boolean) => unknown;
 };
 
 type ActiveFixturePath = null | string;
@@ -77,9 +77,10 @@ export function FixtureSearchOverlay({
   );
 
   const onInputKeyDown = React.useMemo(() => {
-    function handleEnter() {
+    function handleEnter(revealFixture: boolean) {
       if (activeFixturePath !== null) {
-        onSelect(fixtureIds[activeFixturePath]);
+        const fixtureId = fixtureIds[activeFixturePath];
+        onSelect(fixtureId, revealFixture);
       }
     }
 
@@ -144,7 +145,7 @@ export function FixtureSearchOverlay({
           return onClose();
         case KEY_ENTER:
           e.preventDefault();
-          return handleEnter();
+          return handleEnter(e.shiftKey);
         case KEY_UP:
           e.preventDefault();
           return handleUp();

--- a/packages/react-cosmos-playground2/src/plugins/FixtureSearch/FixtureSearchResult.tsx
+++ b/packages/react-cosmos-playground2/src/plugins/FixtureSearch/FixtureSearchResult.tsx
@@ -15,7 +15,7 @@ export function FixtureSearchResult({
   active,
   onSelect
 }: Props) {
-  const containerRef = useContainerRef(cleanFixturePath, active);
+  const containerRef = useScrollToActive(cleanFixturePath, active);
   const onClick = React.useCallback(() => onSelect(fixtureId, false), [
     fixtureId,
     onSelect
@@ -28,9 +28,10 @@ export function FixtureSearchResult({
   );
 }
 
-function useContainerRef(cleanFixturePath: string, active: boolean) {
+function useScrollToActive(cleanFixturePath: string, active: boolean) {
   const containerRef = React.useRef<HTMLDivElement | null>(null);
 
+  // Scroll to results when they become active
   React.useEffect((): ReturnType<React.EffectCallback> => {
     const containerNode = containerRef.current;
     if (active && containerNode) {

--- a/packages/react-cosmos-playground2/src/plugins/FixtureSearch/FixtureSearchResult.tsx
+++ b/packages/react-cosmos-playground2/src/plugins/FixtureSearch/FixtureSearchResult.tsx
@@ -15,22 +15,31 @@ export function FixtureSearchResult({
   active,
   onSelect
 }: Props) {
-  // Scroll to results when they become active
-  const containerRef = (containerNode: HTMLDivElement | null) => {
-    if (containerNode && active) {
-      scrollIntoView(containerNode);
-    }
-  };
+  const containerRef = useContainerRef(cleanFixturePath, active);
+  const onClick = React.useCallback(() => onSelect(fixtureId, false), [
+    fixtureId,
+    onSelect
+  ]);
 
   return (
-    <Container
-      ref={containerRef}
-      active={active}
-      onClick={() => onSelect(fixtureId, false)}
-    >
+    <Container ref={containerRef} active={active} onClick={onClick}>
       {cleanFixturePath}
     </Container>
   );
+}
+
+function useContainerRef(cleanFixturePath: string, active: boolean) {
+  const containerRef = React.useRef<HTMLDivElement | null>(null);
+
+  React.useEffect((): ReturnType<React.EffectCallback> => {
+    const containerNode = containerRef.current;
+    if (active && containerNode) {
+      const timeoutId = setTimeout(() => scrollIntoView(containerNode), 0);
+      return () => clearTimeout(timeoutId);
+    }
+  }, [cleanFixturePath, active]);
+
+  return containerRef;
 }
 
 function scrollIntoView(node: HTMLElement) {

--- a/packages/react-cosmos-playground2/src/plugins/FixtureSearch/FixtureSearchResult.tsx
+++ b/packages/react-cosmos-playground2/src/plugins/FixtureSearch/FixtureSearchResult.tsx
@@ -6,7 +6,7 @@ type Props = {
   cleanFixturePath: string;
   fixtureId: FixtureId;
   active: boolean;
-  onSelect: (fixtureId: FixtureId) => unknown;
+  onSelect: (fixtureId: FixtureId, revealFixture: boolean) => unknown;
 };
 
 export function FixtureSearchResult({
@@ -26,7 +26,7 @@ export function FixtureSearchResult({
     <Container
       ref={containerRef}
       active={active}
-      onClick={() => onSelect(fixtureId)}
+      onClick={() => onSelect(fixtureId, false)}
     >
       {cleanFixturePath}
     </Container>

--- a/packages/react-cosmos-playground2/src/plugins/FixtureSearch/FixtureSearchResult.tsx
+++ b/packages/react-cosmos-playground2/src/plugins/FixtureSearch/FixtureSearchResult.tsx
@@ -16,16 +16,18 @@ export function FixtureSearchResult({
   onSelect
 }: Props) {
   // Scroll to results when they become active
-  const elRef = React.useRef<HTMLDivElement>(null);
-  React.useEffect(() => {
-    const containerNode = elRef.current;
-    if (active && containerNode) {
+  const containerRef = (containerNode: HTMLDivElement | null) => {
+    if (containerNode && active) {
       scrollIntoView(containerNode);
     }
-  }, [active]);
+  };
 
   return (
-    <Container ref={elRef} active={active} onClick={() => onSelect(fixtureId)}>
+    <Container
+      ref={containerRef}
+      active={active}
+      onClick={() => onSelect(fixtureId)}
+    >
       {cleanFixturePath}
     </Container>
   );

--- a/packages/react-cosmos-playground2/src/plugins/FixtureSearch/FixtureSearchResult.tsx
+++ b/packages/react-cosmos-playground2/src/plugins/FixtureSearch/FixtureSearchResult.tsx
@@ -32,11 +32,10 @@ function useScrollToActive(cleanFixturePath: string, active: boolean) {
   const containerRef = React.useRef<HTMLDivElement | null>(null);
 
   // Scroll to results when they become active
-  React.useEffect((): ReturnType<React.EffectCallback> => {
+  React.useLayoutEffect(() => {
     const containerNode = containerRef.current;
     if (active && containerNode) {
-      const timeoutId = setTimeout(() => scrollIntoView(containerNode), 0);
-      return () => clearTimeout(timeoutId);
+      scrollIntoView(containerNode);
     }
   }, [cleanFixturePath, active]);
 
@@ -45,7 +44,7 @@ function useScrollToActive(cleanFixturePath: string, active: boolean) {
 
 function scrollIntoView(node: HTMLElement) {
   if (typeof node.scrollIntoView === 'function') {
-    node.scrollIntoView({ behavior: 'smooth', block: 'center' });
+    node.scrollIntoView({ block: 'center' });
   }
 }
 

--- a/packages/react-cosmos-playground2/src/plugins/FixtureSearch/flattenFixtureTree.tsx
+++ b/packages/react-cosmos-playground2/src/plugins/FixtureSearch/flattenFixtureTree.tsx
@@ -1,5 +1,5 @@
 import { FixtureId } from 'react-cosmos-shared2/renderer';
-import { TreeNode } from '../../shared/tree';
+import { getSortedNodeDirNames, TreeNode } from '../../shared/tree';
 
 export type FixtureIdsByPath = Record<string, FixtureId>;
 
@@ -9,7 +9,7 @@ export function flattenFixtureTree(
 ): FixtureIdsByPath {
   const fixtureIds: FixtureIdsByPath = {};
 
-  Object.keys(fixtureTree.dirs).forEach(dirName => {
+  getSortedNodeDirNames(fixtureTree.dirs).forEach(dirName => {
     const dir = fixtureTree.dirs[dirName];
     const dirFlatItems = flattenFixtureTree(dir, [...parents, dirName]);
     Object.keys(dirFlatItems).forEach(dirItemCleanPath => {

--- a/packages/react-cosmos-playground2/src/plugins/FixtureSearch/flattenFixtureTree.tsx
+++ b/packages/react-cosmos-playground2/src/plugins/FixtureSearch/flattenFixtureTree.tsx
@@ -9,17 +9,17 @@ export function flattenFixtureTree(
 ): FixtureIdsByPath {
   const fixtureIds: FixtureIdsByPath = {};
 
-  Object.keys(fixtureTree.items).forEach(itemName => {
-    const cleanPath = [...parents, itemName].join(' ');
-    fixtureIds[cleanPath] = fixtureTree.items[itemName];
-  });
-
   Object.keys(fixtureTree.dirs).forEach(dirName => {
     const dir = fixtureTree.dirs[dirName];
     const dirFlatItems = flattenFixtureTree(dir, [...parents, dirName]);
     Object.keys(dirFlatItems).forEach(dirItemCleanPath => {
       fixtureIds[dirItemCleanPath] = dirFlatItems[dirItemCleanPath];
     });
+  });
+
+  Object.keys(fixtureTree.items).forEach(itemName => {
+    const cleanPath = [...parents, itemName].join(' ');
+    fixtureIds[cleanPath] = fixtureTree.items[itemName];
   });
 
   return fixtureIds;

--- a/packages/react-cosmos-playground2/src/plugins/FixtureSearch/index.test.tsx
+++ b/packages/react-cosmos-playground2/src/plugins/FixtureSearch/index.test.tsx
@@ -5,6 +5,7 @@ import { register } from '.';
 import { cleanup } from '../../testHelpers/plugin';
 import {
   mockCore,
+  mockFixtureTree,
   mockRendererCore,
   mockRouter
 } from '../../testHelpers/pluginMocks';
@@ -28,6 +29,7 @@ function registerTestPlugins() {
   mockRendererCore({
     getFixtures: () => fixtures
   });
+  mockFixtureTree();
 }
 
 function loadTestPlugins() {

--- a/packages/react-cosmos-playground2/src/plugins/FixtureSearch/index.tsx
+++ b/packages/react-cosmos-playground2/src/plugins/FixtureSearch/index.tsx
@@ -56,6 +56,7 @@ namedPlug('global', 'fixtureSearch', ({ pluginContext }) => {
       fixturesDir={fixturesDir}
       fixtureFileSuffix={fixtureFileSuffix}
       fixtures={fixtures}
+      selectedFixtureId={router.getSelectedFixtureId()}
       onClose={onClose}
       onSelect={onSelect}
     />

--- a/packages/react-cosmos-playground2/src/plugins/FixtureSearch/index.tsx
+++ b/packages/react-cosmos-playground2/src/plugins/FixtureSearch/index.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { FixtureId } from 'react-cosmos-shared2/renderer';
 import { createPlugin } from 'react-plugin';
 import { CoreSpec } from '../Core/public';
+import { FixtureTreeSpec } from '../FixtureTree/public';
 import { RendererCoreSpec } from '../RendererCore/public';
 import { RouterSpec } from '../Router/public';
 import { FixtureSearchHeader } from './FixtureSearchHeader';
@@ -35,16 +36,20 @@ namedPlug('global', 'fixtureSearch', ({ pluginContext }) => {
   const router = getMethodsOf<RouterSpec>('router');
   const { fixturesDir, fixtureFileSuffix } = core.getFixtureFileVars();
   const rendererCore = getMethodsOf<RendererCoreSpec>('rendererCore');
+  const fixtureTree = getMethodsOf<FixtureTreeSpec>('fixtureTree');
   const fixtures = rendererCore.getFixtures();
   const onClose = React.useCallback(() => setState({ open: false }), [
     setState
   ]);
   const onSelect = React.useCallback(
-    (fixtureId: FixtureId) => {
+    (fixtureId: FixtureId, revealFixture: boolean) => {
       router.selectFixture(fixtureId, false);
+      if (revealFixture) {
+        fixtureTree.revealFixture(fixtureId);
+      }
       setState({ open: false });
     },
-    [router, setState]
+    [fixtureTree, router, setState]
   );
 
   if (!open) {

--- a/packages/react-cosmos-playground2/src/plugins/FixtureTree/FixtureTree/FixtureTreeDir.tsx
+++ b/packages/react-cosmos-playground2/src/plugins/FixtureTree/FixtureTree/FixtureTreeDir.tsx
@@ -1,23 +1,39 @@
 import React from 'react';
+import { isEqual } from 'lodash';
+import { FixtureId } from 'react-cosmos-shared2/renderer';
 import styled from 'styled-components';
+import { FixtureNode } from '../../../shared/fixtureTree';
 import {
   ChevronDownIcon,
   ChevronRightIcon,
   FolderIcon
 } from '../../../shared/icons';
-import { ListItem, Unshirinkable, Label } from './shared';
+import { Label, ListItem, Unshirinkable } from './shared';
 
 type Props = {
+  node: FixtureNode;
   parents: string[];
   isExpanded: boolean;
+  selectedFixtureId: null | FixtureId;
   onToggle: () => unknown;
 };
 
-export function FixtureTreeDir({ parents, isExpanded, onToggle }: Props) {
+export function FixtureTreeDir({
+  node,
+  parents,
+  selectedFixtureId,
+  isExpanded,
+  onToggle
+}: Props) {
   const dirName = parents[parents.length - 1];
+  const containsSelectedFixture =
+    selectedFixtureId !== null && treeContainsFixture(node, selectedFixtureId);
   return (
     <DirButton onClick={onToggle}>
-      <ListItem indentLevel={parents.length - 1}>
+      <ListItem
+        indentLevel={parents.length - 1}
+        selected={!isExpanded && containsSelectedFixture}
+      >
         <CevronContainer>
           {isExpanded ? <ChevronDownIcon /> : <ChevronRightIcon />}
         </CevronContainer>
@@ -27,6 +43,21 @@ export function FixtureTreeDir({ parents, isExpanded, onToggle }: Props) {
         <Label>{dirName}</Label>
       </ListItem>
     </DirButton>
+  );
+}
+
+function treeContainsFixture(
+  { dirs, items }: FixtureNode,
+  fixtureId: FixtureId
+): boolean {
+  const itemNames = Object.keys(items);
+  if (itemNames.some(itemName => isEqual(items[itemName], fixtureId))) {
+    return true;
+  }
+
+  const dirNames = Object.keys(dirs);
+  return dirNames.some(dirName =>
+    treeContainsFixture(dirs[dirName], fixtureId)
   );
 }
 

--- a/packages/react-cosmos-playground2/src/plugins/FixtureTree/FixtureTree/index.fixture.tsx
+++ b/packages/react-cosmos-playground2/src/plugins/FixtureTree/FixtureTree/index.fixture.tsx
@@ -42,7 +42,7 @@ function createFixtureTree(
       treeExpansion={treeExpansion}
       onSelect={selectedFixtureId => console.log('select', selectedFixtureId)}
       setTreeExpansion={newTreeExpansion =>
-        console.log('set tree expansion', treeExpansion)
+        console.log('set tree expansion', newTreeExpansion)
       }
     />
   );

--- a/packages/react-cosmos-playground2/src/plugins/FixtureTree/FixtureTree/index.fixture.tsx
+++ b/packages/react-cosmos-playground2/src/plugins/FixtureTree/FixtureTree/index.fixture.tsx
@@ -1,0 +1,49 @@
+import React from 'react';
+import { FixtureId } from 'react-cosmos-shared2/renderer';
+import { FixtureTree } from '.';
+import { TreeExpansion } from '../../../shared/ui/TreeView';
+
+const fixtures = {
+  'src/fixture1.ts': null,
+  'src/fixture2.ts': null,
+  'src/dir1/fixture3.ts': null,
+  'src/dir1/fixture4.ts': ['fixtureA', 'fixtureB']
+};
+
+const fixtureBId = { path: 'src/dir1/fixture4.ts', name: 'fixtureB' };
+
+export default {
+  collapsed: createFixtureTree(),
+
+  expanded1: createFixtureTree({ dir1: true }),
+
+  expanded2: createFixtureTree({ dir1: true, 'dir1/fixture4': true }),
+
+  'selected collapsed': createFixtureTree({}, fixtureBId),
+
+  'selected expanded1': createFixtureTree({ dir1: true }, fixtureBId),
+
+  'selected expanded2': createFixtureTree(
+    { dir1: true, 'dir1/fixture4': true },
+    fixtureBId
+  )
+};
+
+function createFixtureTree(
+  treeExpansion: TreeExpansion = {},
+  fixtureId: null | FixtureId = null
+) {
+  return (
+    <FixtureTree
+      fixturesDir="__fixtures__"
+      fixtureFileSuffix="fixture"
+      fixtures={fixtures}
+      selectedFixtureId={fixtureId}
+      treeExpansion={treeExpansion}
+      onSelect={selectedFixtureId => console.log('select', selectedFixtureId)}
+      setTreeExpansion={newTreeExpansion =>
+        console.log('set tree expansion', treeExpansion)
+      }
+    />
+  );
+}

--- a/packages/react-cosmos-playground2/src/plugins/FixtureTree/FixtureTree/index.tsx
+++ b/packages/react-cosmos-playground2/src/plugins/FixtureTree/FixtureTree/index.tsx
@@ -34,10 +34,12 @@ export const FixtureTree = React.memo(function FixtureTree({
       <TreeView
         node={rootNode}
         treeExpansion={treeExpansion}
-        renderDir={({ parents, isExpanded, onToggle }) => (
+        renderDir={({ node, parents, isExpanded, onToggle }) => (
           <FixtureTreeDir
+            node={node}
             parents={parents}
             isExpanded={isExpanded}
+            selectedFixtureId={selectedFixtureId}
             onToggle={onToggle}
           />
         )}
@@ -61,4 +63,5 @@ const Container = styled.div`
   display: inline-block;
   min-width: 100%;
   padding: 8px 0;
+  background: var(--grey1);
 `;

--- a/packages/react-cosmos-playground2/src/plugins/FixtureTree/public.ts
+++ b/packages/react-cosmos-playground2/src/plugins/FixtureTree/public.ts
@@ -1,3 +1,8 @@
+import { FixtureId } from 'react-cosmos-shared2/renderer';
+
 export type FixtureTreeSpec = {
   name: 'fixtureTree';
+  methods: {
+    revealFixture: (fixtureId: FixtureId) => unknown;
+  };
 };

--- a/packages/react-cosmos-playground2/src/plugins/FixtureTree/revealFixture.ts
+++ b/packages/react-cosmos-playground2/src/plugins/FixtureTree/revealFixture.ts
@@ -1,0 +1,70 @@
+import { isEqual } from 'lodash';
+import { FixtureId } from 'react-cosmos-shared2/renderer';
+import { createFixtureTree } from '../../shared/fixtureTree';
+import { FixtureNode } from '../../shared/fixtureTree/shared';
+import { TreeExpansion } from '../../shared/ui/TreeView';
+import { CoreSpec } from '../Core/public';
+import { RendererCoreSpec } from '../RendererCore/public';
+import { StorageSpec } from '../Storage/public';
+import {
+  FixtureTreeContext,
+  getTreeExpansion,
+  setTreeExpansion
+} from './shared';
+
+export function revealFixture(
+  pluginContext: FixtureTreeContext,
+  fixtureId: FixtureId
+) {
+  const { getMethodsOf } = pluginContext;
+  const storage = pluginContext.getMethodsOf<StorageSpec>('storage');
+  const core = getMethodsOf<CoreSpec>('core');
+  const rendererCore = getMethodsOf<RendererCoreSpec>('rendererCore');
+  const { fixturesDir, fixtureFileSuffix } = core.getFixtureFileVars();
+  const fixtures = rendererCore.getFixtures();
+
+  const rootFixtureNode = createFixtureTree({
+    fixtures,
+    fixturesDir,
+    fixtureFileSuffix
+  });
+  const nodePath = getFixtureDirNodePath(rootFixtureNode, fixtureId);
+  if (nodePath) {
+    const treeExpansion = getTreeExpansion(storage);
+    const curNodePath = [];
+    const curTreeExpansion: TreeExpansion = { ...treeExpansion };
+    for (let pathIndex = 0; pathIndex < nodePath.length; pathIndex++) {
+      curNodePath.push(nodePath[pathIndex]);
+      curTreeExpansion[curNodePath.join('/')] = true;
+    }
+    setTreeExpansion(storage, curTreeExpansion);
+  }
+}
+
+function getFixtureDirNodePath(
+  { dirs, items }: FixtureNode,
+  fixtureId: FixtureId,
+  atPath: string[] = []
+): null | string[] {
+  const itemNames = Object.keys(items);
+  const dirPath = itemNames.find(itemName =>
+    isEqual(items[itemName], fixtureId)
+  );
+  if (dirPath) {
+    return atPath;
+  }
+
+  const dirNames = Object.keys(dirs);
+  for (let dirIndex = 0; dirIndex < dirNames.length; dirIndex++) {
+    const dirName = dirNames[dirIndex];
+    const childDirPath = getFixtureDirNodePath(dirs[dirName], fixtureId, [
+      ...atPath,
+      dirName
+    ]);
+    if (childDirPath) {
+      return childDirPath;
+    }
+  }
+
+  return null;
+}

--- a/packages/react-cosmos-playground2/src/plugins/FixtureTree/shared.ts
+++ b/packages/react-cosmos-playground2/src/plugins/FixtureTree/shared.ts
@@ -1,1 +1,23 @@
-export const TREE_EXPANSION_STORAGE_KEY = 'fixtureTreeExpansion';
+import { PluginContext } from 'react-plugin';
+import { TreeExpansion } from '../../shared/ui/TreeView';
+import { StorageSpec } from '../Storage/public';
+import { FixtureTreeSpec } from './public';
+
+export type FixtureTreeContext = PluginContext<FixtureTreeSpec>;
+
+const TREE_EXPANSION_STORAGE_KEY = 'fixtureTreeExpansion';
+
+const DEFAULT_TREE_EXPANSION = {};
+
+export function getTreeExpansion({ getItem }: StorageSpec['methods']) {
+  return (
+    getItem<TreeExpansion>(TREE_EXPANSION_STORAGE_KEY) || DEFAULT_TREE_EXPANSION
+  );
+}
+
+export function setTreeExpansion(
+  { setItem }: StorageSpec['methods'],
+  treeExpansion: TreeExpansion
+) {
+  setItem(TREE_EXPANSION_STORAGE_KEY, treeExpansion);
+}

--- a/packages/react-cosmos-playground2/src/shared/tree.ts
+++ b/packages/react-cosmos-playground2/src/shared/tree.ts
@@ -6,3 +6,24 @@ export type TreeNode<Item> = {
 export type TreeNodeDirs<Item> = {
   [dirName: string]: TreeNode<Item>;
 };
+
+export function getSortedNodeDirNames(nodeDirs: TreeNodeDirs<any>): string[] {
+  return (
+    Object.keys(nodeDirs)
+      .slice()
+      // Sort alphabetically first
+      .sort()
+      .sort((dirName1, dirName2) => {
+        return (
+          calcNodeDepth(nodeDirs[dirName2]) - calcNodeDepth(nodeDirs[dirName1])
+        );
+      })
+  );
+}
+
+// Only differentiate between nodes with and without subdirs and ignore
+// depth level in the latter
+function calcNodeDepth(node: TreeNode<any>): 0 | 1 {
+  const hasDirs = Object.keys(node.dirs).length > 0;
+  return hasDirs ? 1 : 0;
+}

--- a/packages/react-cosmos-playground2/src/shared/ui/TreeView.tsx
+++ b/packages/react-cosmos-playground2/src/shared/ui/TreeView.tsx
@@ -1,6 +1,6 @@
 import { map } from 'lodash';
 import React from 'react';
-import { TreeNode } from '../tree';
+import { getSortedNodeDirNames, TreeNode } from '../tree';
 
 export type TreeExpansion = {
   [nodePath: string]: boolean;
@@ -46,7 +46,7 @@ export function TreeView<Item>({
       {!isRootNode && renderDir({ node, parents, isExpanded, onToggle })}
       {isExpanded && (
         <>
-          {getSortedNodeDirNames(node).map(dirName => {
+          {getSortedNodeDirNames(dirs).map(dirName => {
             const nextParents = [...parents, dirName];
             return (
               <TreeView
@@ -69,28 +69,6 @@ export function TreeView<Item>({
       )}
     </>
   );
-}
-
-function getSortedNodeDirNames(node: TreeNode<any>): string[] {
-  return (
-    Object.keys(node.dirs)
-      .slice()
-      // Sort alphabetically first
-      .sort()
-      .sort((dirName1, dirName2) => {
-        return (
-          calcNodeDepth(node.dirs[dirName2]) -
-          calcNodeDepth(node.dirs[dirName1])
-        );
-      })
-  );
-}
-
-// Only differentiate between nodes with and without subdirs and ignore
-// depth level in the latter
-function calcNodeDepth(node: TreeNode<any>): 0 | 1 {
-  const hasDirs = Object.keys(node.dirs).length > 0;
-  return hasDirs ? 1 : 0;
 }
 
 function getNodePath(nodeParents: string[]) {

--- a/packages/react-cosmos-playground2/src/testHelpers/pluginMocks.ts
+++ b/packages/react-cosmos-playground2/src/testHelpers/pluginMocks.ts
@@ -1,17 +1,18 @@
 import {
-  PluginSpec,
-  MethodHandlers,
   EventHandlers,
-  getPluginContext
+  getPluginContext,
+  MethodHandlers,
+  PluginSpec
 } from 'react-plugin';
-import { StorageSpec } from '../plugins/Storage/public';
-import { RouterSpec } from '../plugins/Router/public';
 import { CoreSpec } from '../plugins/Core/public';
-import { MessageHandlerSpec } from '../plugins/MessageHandler/public';
-import { RendererCoreSpec } from '../plugins/RendererCore/public';
+import { FixtureTreeSpec } from '../plugins/FixtureTree/public';
 import { LayoutSpec } from '../plugins/Layout/public';
+import { MessageHandlerSpec } from '../plugins/MessageHandler/public';
 import { NotificationsSpec } from '../plugins/Notifications/public';
+import { RendererCoreSpec } from '../plugins/RendererCore/public';
 import { RendererPreviewSpec } from '../plugins/RendererPreview/public';
+import { RouterSpec } from '../plugins/Router/public';
+import { StorageSpec } from '../plugins/Storage/public';
 import { getMethodsOf, mockMethodsOf, on } from './plugin';
 
 type MethodsOf<Spec extends PluginSpec> = Partial<MethodHandlers<Spec>>;
@@ -150,6 +151,15 @@ export function mockNotifications(methods: MethodsOf<NotificationsSpec> = {}) {
     ...methods
   };
   mockMethodsOf<NotificationsSpec>('notifications', allMethods);
+  return allMethods;
+}
+
+export function mockFixtureTree(methods: MethodsOf<FixtureTreeSpec> = {}) {
+  const allMethods = {
+    revealFixture: jest.fn(),
+    ...methods
+  };
+  mockMethodsOf<FixtureTreeSpec>('fixtureTree', allMethods);
   return allMethods;
 }
 

--- a/packages/react-cosmos/config.schema.json
+++ b/packages/react-cosmos/config.schema.json
@@ -4,6 +4,9 @@
   "type": "object",
   "additionalProperties": false,
   "properties": {
+    "$schema": {
+      "type": "string"
+    },
     "rootDir": {
       "description": "The root directory that all others paths in this config are relative to. Usually the root of your repo. If omitted, rootDir is equal to the directory containing your Cosmos config. When you don't use a Cosmos config, rootDir defaults to the current working directory.",
       "type": "string",

--- a/packages/react-cosmos/src/shared/userDeps/shared.ts
+++ b/packages/react-cosmos/src/shared/userDeps/shared.ts
@@ -6,7 +6,7 @@ const FIXTURE_PATTERNS = [
   '**/*.<fixtureFileSuffix>.{js,jsx,ts,tsx}'
 ];
 const DECORATOR_PATTERNS = ['**/cosmos.decorator.{js,jsx,ts,tsx}'];
-const IGNORE_PATTERNS = ['**/node_modules/**', '**/dist/**'];
+const IGNORE_PATTERNS = ['**/node_modules/**'];
 
 export function getFixturePatterns(
   fixturesDir: string,


### PR DESCRIPTION
- [x] Highlight collapsed parent folders containing the selected fixture
- [x] Highlight selected fixture when opening search overlay
- [x] Reveal fixture in tree view on [shift] + [enter] in search list
- [x] Make fixture order in search list consistent with tree view order