### PR TITLE
Improve responsive preview

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -39,6 +39,7 @@ Control panel
   - Inputs
     - [x] Text value
     - [x] Number value
+      - [ ] Support decimals
     - [x] Boolean value
     - [x] Null value
   - [x] Style

--- a/TODO.md
+++ b/TODO.md
@@ -8,15 +8,15 @@ Alpha
 - [x] Notifications redesign
   - [x] Build notification [#522](https://github.com/react-cosmos/react-cosmos/issues/522)
   - [x] ~~Try: Notifications for fixture create/remove/rename~~ Too much info to display inside a notification
-- [x] Control panel
+- [ ] Control panel
 - [x] Fixture search
   - [x] Minimize left nav
 - [x] Official React Native integration
   - [x] NativeFixtureLoader facade
   - [x] Hybrid Cosmos: Mirror dom and native renderers
-- [ ] Resize responsive viewport
-  - [ ] Put viewports in dropdown
-  - [ ] Make width/height inputs
+- [x] Resize responsive viewport
+  - [x] Put viewports in dropdown
+  - [x] Make width/height inputs
 - [ ] Mass fixture snapshots
 - [ ] Refresh docs
 

--- a/packages/react-cosmos-playground2/src/plugins/ClassStatePanel/ClassStatePanel/index.fixture.tsx
+++ b/packages/react-cosmos-playground2/src/plugins/ClassStatePanel/ClassStatePanel/index.fixture.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import styled from 'styled-components';
 import { FixtureState } from 'react-cosmos-shared2/fixtureState';
-import { Viewport } from 'react-cosmos-fixture';
 import { stringifyElementId } from '../../../shared/ui/valueInputTree';
 import { ClassStatePanel } from '.';
 
@@ -108,19 +107,17 @@ export default () => {
 
   return (
     <Container>
-      <Viewport width={220} height={400}>
-        <ClassStatePanel
-          fixtureState={fixtureState}
-          fixtureExpansion={fixtureExpansion}
-          onFixtureStateChange={setFixtureState}
-          onElementExpansionChange={(elementId, treeExpansion) => {
-            setFixtureExpansion({
-              ...fixtureExpansion,
-              [stringifyElementId(elementId)]: treeExpansion
-            });
-          }}
-        />
-      </Viewport>
+      <ClassStatePanel
+        fixtureState={fixtureState}
+        fixtureExpansion={fixtureExpansion}
+        onFixtureStateChange={setFixtureState}
+        onElementExpansionChange={(elementId, treeExpansion) => {
+          setFixtureExpansion({
+            ...fixtureExpansion,
+            [stringifyElementId(elementId)]: treeExpansion
+          });
+        }}
+      />
     </Container>
   );
 };

--- a/packages/react-cosmos-playground2/src/plugins/FixtureTree/BlankState.fixture.tsx
+++ b/packages/react-cosmos-playground2/src/plugins/FixtureTree/BlankState.fixture.tsx
@@ -1,9 +1,6 @@
 import React from 'react';
 import { BlankState } from './BlankState';
-import { Viewport } from 'react-cosmos-fixture';
 
 export default (
-  <Viewport width={320} height={480}>
-    <BlankState fixturesDir="__fixtures__" fixtureFileSuffix="fixture" />
-  </Viewport>
+  <BlankState fixturesDir="__fixtures__" fixtureFileSuffix="fixture" />
 );

--- a/packages/react-cosmos-playground2/src/plugins/PropsPanel/PropsPanel/index.fixture.tsx
+++ b/packages/react-cosmos-playground2/src/plugins/PropsPanel/PropsPanel/index.fixture.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import styled from 'styled-components';
 import { FixtureState } from 'react-cosmos-shared2/fixtureState';
-import { Viewport } from 'react-cosmos-fixture';
 import { stringifyElementId } from '../../../shared/ui/valueInputTree';
 import { PropsPanel } from '.';
 

--- a/packages/react-cosmos-playground2/src/plugins/PropsPanel/PropsPanel/index.fixture.tsx
+++ b/packages/react-cosmos-playground2/src/plugins/PropsPanel/PropsPanel/index.fixture.tsx
@@ -110,19 +110,17 @@ export default () => {
 
   return (
     <Container>
-      <Viewport width={220} height={400}>
-        <PropsPanel
-          fixtureState={fixtureState}
-          fixtureExpansion={fixtureExpansion}
-          onFixtureStateChange={setFixtureState}
-          onElementExpansionChange={(elementId, treeExpansion) => {
-            setFixtureExpansion({
-              ...fixtureExpansion,
-              [stringifyElementId(elementId)]: treeExpansion
-            });
-          }}
-        />
-      </Viewport>
+      <PropsPanel
+        fixtureState={fixtureState}
+        fixtureExpansion={fixtureExpansion}
+        onFixtureStateChange={setFixtureState}
+        onElementExpansionChange={(elementId, treeExpansion) => {
+          setFixtureExpansion({
+            ...fixtureExpansion,
+            [stringifyElementId(elementId)]: treeExpansion
+          });
+        }}
+      />
     </Container>
   );
 };

--- a/packages/react-cosmos-playground2/src/plugins/ResponsivePreview/ResponsivePreview/Header.fixture.tsx
+++ b/packages/react-cosmos-playground2/src/plugins/ResponsivePreview/ResponsivePreview/Header.fixture.tsx
@@ -2,7 +2,8 @@ import React from 'react';
 import { DEFAULT_DEVICES } from '../shared';
 import { Header } from './Header';
 
-const initialViewport = { width: 1240, height: 1360 };
+const { width, height } = DEFAULT_DEVICES[0];
+const initialViewport = { width, height };
 
 export default {
   stateless: (

--- a/packages/react-cosmos-playground2/src/plugins/ResponsivePreview/ResponsivePreview/Header.fixture.tsx
+++ b/packages/react-cosmos-playground2/src/plugins/ResponsivePreview/ResponsivePreview/Header.fixture.tsx
@@ -1,9 +1,11 @@
 import React from 'react';
 import { DEFAULT_DEVICES } from '../shared';
 import { Header } from './Header';
+import { getViewportScaleFactor } from './style';
 
 const { width, height } = DEFAULT_DEVICES[0];
 const initialViewport = { width, height };
+const containerViewport = { width: 640, height: 480 };
 
 export default {
   stateless: (
@@ -20,11 +22,12 @@ export default {
   stateful: function ViewportContainer() {
     const [viewport, setViewport] = React.useState(initialViewport);
     const [scaled, setScaled] = React.useState(false);
+    const scaleFactor = getViewportScaleFactor(viewport, containerViewport);
     return (
       <Header
         devices={DEFAULT_DEVICES}
         selectedViewport={viewport}
-        scaleFactor={0.75}
+        scaleFactor={scaleFactor}
         scaled={scaled}
         selectViewport={setViewport}
         toggleScale={() => setScaled(!scaled)}

--- a/packages/react-cosmos-playground2/src/plugins/ResponsivePreview/ResponsivePreview/Header.fixture.tsx
+++ b/packages/react-cosmos-playground2/src/plugins/ResponsivePreview/ResponsivePreview/Header.fixture.tsx
@@ -1,0 +1,33 @@
+import React from 'react';
+import { DEFAULT_DEVICES } from '../shared';
+import { Header } from './Header';
+
+const initialViewport = { width: 1240, height: 1360 };
+
+export default {
+  stateless: (
+    <Header
+      devices={DEFAULT_DEVICES}
+      selectedViewport={initialViewport}
+      scaleFactor={0.75}
+      scaled={false}
+      selectViewport={viewport => console.log('Select viewport', viewport)}
+      toggleScale={() => console.log('Toggle scale')}
+    />
+  ),
+
+  stateful: function ViewportContainer() {
+    const [viewport, setViewport] = React.useState(initialViewport);
+    const [scaled, setScaled] = React.useState(false);
+    return (
+      <Header
+        devices={DEFAULT_DEVICES}
+        selectedViewport={viewport}
+        scaleFactor={0.75}
+        scaled={scaled}
+        selectViewport={setViewport}
+        toggleScale={() => setScaled(!scaled)}
+      />
+    );
+  }
+};

--- a/packages/react-cosmos-playground2/src/plugins/ResponsivePreview/ResponsivePreview/Header.tsx
+++ b/packages/react-cosmos-playground2/src/plugins/ResponsivePreview/ResponsivePreview/Header.tsx
@@ -24,11 +24,11 @@ export class Header extends React.Component<Props> {
       toggleScale
     } = this.props;
     const canScale = scaleFactor < 1;
-
     return (
       <Container data-testid="responsiveHeader">
         <Left>
           <select
+            data-testid="viewportSelect"
             value={stringifyViewport(selectedViewport)}
             onChange={e => selectViewport(parseViewport(e.target.value))}
           >
@@ -74,11 +74,11 @@ export class Header extends React.Component<Props> {
 }
 
 function stringifyViewport({ width, height }: Viewport) {
-  return `${width}-${height}`;
+  return `${width}x${height}`;
 }
 
 function parseViewport(str: string) {
-  const [width, height] = str.split('-');
+  const [width, height] = str.split('x');
   return { width: Number(width), height: Number(height) };
 }
 

--- a/packages/react-cosmos-playground2/src/plugins/ResponsivePreview/ResponsivePreview/Header.tsx
+++ b/packages/react-cosmos-playground2/src/plugins/ResponsivePreview/ResponsivePreview/Header.tsx
@@ -21,74 +21,72 @@ const numberInputStypes = {
   focusedBoxShadow: '0 0 1px 1px var(--primary4)'
 };
 
-export class Header extends React.Component<Props> {
-  render() {
-    const {
-      devices,
-      selectedViewport,
-      scaleFactor,
-      scaled,
-      selectViewport,
-      toggleScale
-    } = this.props;
-    const canScale = scaleFactor < 1;
-
-    const options = devices.map(({ width, height, label }) => {
-      const value = stringifyViewport({ width, height });
-      return { value, label, width, height };
-    });
-    return (
-      <Container data-testid="responsiveHeader">
-        <Left>
-          <Select
-            testId="viewportSelect"
-            options={options}
-            value={stringifyViewport(selectedViewport)}
-            onChange={option =>
-              selectViewport({ width: option.width, height: option.height })
-            }
+export function Header({
+  devices,
+  selectedViewport,
+  scaleFactor,
+  scaled,
+  selectViewport,
+  toggleScale
+}: Props) {
+  const options = React.useMemo(
+    () =>
+      devices.map(({ width, height, label }) => {
+        const value = stringifyViewport({ width, height });
+        return { value, label, width, height };
+      }),
+    [devices]
+  );
+  const canScale = scaleFactor < 1;
+  return (
+    <Container data-testid="responsiveHeader">
+      <Left>
+        <Select
+          testId="viewportSelect"
+          options={options}
+          value={stringifyViewport(selectedViewport)}
+          onChange={option =>
+            selectViewport({ width: option.width, height: option.height })
+          }
+        />
+      </Left>
+      <Right>
+        <ViewportSize>
+          <NumberInput
+            id="viewport-width"
+            value={selectedViewport.width}
+            minValue={1}
+            maxValue={5120}
+            styles={numberInputStypes}
+            onChange={width => selectViewport({ ...selectedViewport, width })}
           />
-        </Left>
-        <Right>
-          <ViewportSize>
-            <NumberInput
-              id="viewport-width"
-              value={selectedViewport.width}
-              minValue={1}
-              maxValue={5120}
-              styles={numberInputStypes}
-              onChange={width => selectViewport({ ...selectedViewport, width })}
-            />
-            <ViewportX>×</ViewportX>
-            <NumberInput
-              id="viewport-width"
-              value={selectedViewport.height}
-              minValue={1}
-              maxValue={5120}
-              styles={numberInputStypes}
-              onChange={height =>
-                selectViewport({ ...selectedViewport, height })
-              }
-            />
-          </ViewportSize>
-          <Button
-            icon={<Minimize2Icon />}
-            label={
-              <>
-                scale
-                {canScale && (
-                  <ScaleDegree>{getScalePercent(scaleFactor)}</ScaleDegree>
-                )}
-              </>
-            }
-            disabled={!canScale}
-            selected={canScale && scaled}
-            onClick={toggleScale}
+          <ViewportX>×</ViewportX>
+          <NumberInput
+            id="viewport-width"
+            value={selectedViewport.height}
+            minValue={1}
+            maxValue={5120}
+            styles={numberInputStypes}
+            onChange={height => selectViewport({ ...selectedViewport, height })}
           />
-        </Right>
-      </Container>
-    );
-  }
+        </ViewportSize>
+        <Button
+          icon={<Minimize2Icon />}
+          label={
+            <>
+              scale
+              {canScale && (
+                <ScaleDegree>{getScalePercent(scaleFactor)}</ScaleDegree>
+              )}
+            </>
+          }
+          disabled={!canScale}
+          selected={canScale && scaled}
+          onClick={toggleScale}
+        />
+      </Right>
+    </Container>
+  );
 }
 
 function stringifyViewport({ width, height }: Viewport) {

--- a/packages/react-cosmos-playground2/src/plugins/ResponsivePreview/ResponsivePreview/Header.tsx
+++ b/packages/react-cosmos-playground2/src/plugins/ResponsivePreview/ResponsivePreview/Header.tsx
@@ -3,6 +3,7 @@ import styled from 'styled-components';
 import { Minimize2Icon } from '../../../shared/icons';
 import { Button } from '../../../shared/ui/buttons';
 import { Device, Viewport } from '../public';
+import { NumberInput } from '../../../shared/ui/inputs/NumberInput';
 
 type Props = {
   devices: Device[];
@@ -51,7 +52,19 @@ export class Header extends React.Component<Props> {
         </Left>
         <Right>
           <ViewportSize>
-            {`${selectedViewport.width}×${selectedViewport.height}`}
+            <NumberInput
+              id="viewport-width"
+              value={selectedViewport.width}
+              onChange={width => selectViewport({ ...selectedViewport, width })}
+            />
+            <ViewportX>×</ViewportX>
+            <NumberInput
+              id="viewport-width"
+              value={selectedViewport.height}
+              onChange={height =>
+                selectViewport({ ...selectedViewport, height })
+              }
+            />
           </ViewportSize>
           <Button
             icon={<Minimize2Icon />}
@@ -105,6 +118,7 @@ const Left = styled.div`
 `;
 
 const Right = styled.div`
+  height: 32px;
   display: flex;
   flex-direction: row;
   align-items: center;
@@ -120,8 +134,16 @@ const Right = styled.div`
 `;
 
 const ViewportSize = styled.div`
-  margin: 0 8px;
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  margin-left: 8px;
   color: var(--grey3);
+`;
+
+const ViewportX = styled.div`
+  padding: 0 1px;
+  line-height: 32px;
 `;
 
 const ScaleDegree = styled.span`

--- a/packages/react-cosmos-playground2/src/plugins/ResponsivePreview/ResponsivePreview/Header.tsx
+++ b/packages/react-cosmos-playground2/src/plugins/ResponsivePreview/ResponsivePreview/Header.tsx
@@ -4,6 +4,7 @@ import { Minimize2Icon } from '../../../shared/icons';
 import { Button } from '../../../shared/ui/buttons';
 import { Device, Viewport } from '../public';
 import { NumberInput } from '../../../shared/ui/inputs/NumberInput';
+import { Select } from '../../../shared/ui/inputs/Select';
 
 type Props = {
   devices: Device[];
@@ -31,30 +32,22 @@ export class Header extends React.Component<Props> {
       toggleScale
     } = this.props;
     const canScale = scaleFactor < 1;
+
+    const options = devices.map(({ width, height, label }) => {
+      const value = stringifyViewport({ width, height });
+      return { value, label, width, height };
+    });
     return (
       <Container data-testid="responsiveHeader">
         <Left>
-          <select
-            data-testid="viewportSelect"
+          <Select
+            testId="viewportSelect"
+            options={options}
             value={stringifyViewport(selectedViewport)}
-            onChange={e => selectViewport(parseViewport(e.target.value))}
-          >
-            {devices.map(({ label, width, height }, idx) => {
-              const isSelected =
-                selectedViewport &&
-                selectedViewport.width === width &&
-                selectedViewport.height === height;
-              return (
-                <option
-                  key={idx}
-                  value={stringifyViewport({ width, height })}
-                  disabled={isSelected}
-                >
-                  {label}
-                </option>
-              );
-            })}
-          </select>
+            onChange={option =>
+              selectViewport({ width: option.width, height: option.height })
+            }
+          />
         </Left>
         <Right>
           <ViewportSize>
@@ -100,11 +93,6 @@ export class Header extends React.Component<Props> {
 
 function stringifyViewport({ width, height }: Viewport) {
   return `${width}x${height}`;
-}
-
-function parseViewport(str: string) {
-  const [width, height] = str.split('x');
-  return { width: Number(width), height: Number(height) };
 }
 
 function getScalePercent(scaleFactor: number) {

--- a/packages/react-cosmos-playground2/src/plugins/ResponsivePreview/ResponsivePreview/Header.tsx
+++ b/packages/react-cosmos-playground2/src/plugins/ResponsivePreview/ResponsivePreview/Header.tsx
@@ -14,6 +14,12 @@ type Props = {
   toggleScale: () => unknown;
 };
 
+const numberInputStypes = {
+  focusedColor: 'var(--grey2)',
+  focusedBg: 'var(--grey7)',
+  focusedBoxShadow: '0 0 1px 1px var(--primary4)'
+};
+
 export class Header extends React.Component<Props> {
   render() {
     const {
@@ -57,6 +63,7 @@ export class Header extends React.Component<Props> {
               value={selectedViewport.width}
               minValue={1}
               maxValue={5120}
+              styles={numberInputStypes}
               onChange={width => selectViewport({ ...selectedViewport, width })}
             />
             <ViewportX>×</ViewportX>
@@ -65,6 +72,7 @@ export class Header extends React.Component<Props> {
               value={selectedViewport.height}
               minValue={1}
               maxValue={5120}
+              styles={numberInputStypes}
               onChange={height =>
                 selectViewport({ ...selectedViewport, height })
               }
@@ -141,13 +149,14 @@ const ViewportSize = styled.div`
   display: flex;
   flex-direction: row;
   align-items: center;
-  margin-left: 8px;
-  color: var(--grey3);
+  margin: 0 2px;
+  color: var(--grey2);
 `;
 
 const ViewportX = styled.div`
   padding: 0 1px;
   line-height: 32px;
+  color: var(--grey3);
 `;
 
 const ScaleDegree = styled.span`

--- a/packages/react-cosmos-playground2/src/plugins/ResponsivePreview/ResponsivePreview/Header.tsx
+++ b/packages/react-cosmos-playground2/src/plugins/ResponsivePreview/ResponsivePreview/Header.tsx
@@ -53,7 +53,6 @@ export function Header({
       <Right>
         <ViewportSize>
           <NumberInput
-            id="viewport-width"
             value={selectedViewport.width}
             minValue={1}
             maxValue={5120}
@@ -62,7 +61,6 @@ export function Header({
           />
           <ViewportX>×</ViewportX>
           <NumberInput
-            id="viewport-width"
             value={selectedViewport.height}
             minValue={1}
             maxValue={5120}

--- a/packages/react-cosmos-playground2/src/plugins/ResponsivePreview/ResponsivePreview/Header.tsx
+++ b/packages/react-cosmos-playground2/src/plugins/ResponsivePreview/ResponsivePreview/Header.tsx
@@ -55,12 +55,16 @@ export class Header extends React.Component<Props> {
             <NumberInput
               id="viewport-width"
               value={selectedViewport.width}
+              minValue={1}
+              maxValue={5120}
               onChange={width => selectViewport({ ...selectedViewport, width })}
             />
             <ViewportX>×</ViewportX>
             <NumberInput
               id="viewport-width"
               value={selectedViewport.height}
+              minValue={1}
+              maxValue={5120}
               onChange={height =>
                 selectViewport({ ...selectedViewport, height })
               }

--- a/packages/react-cosmos-playground2/src/plugins/ResponsivePreview/ResponsivePreview/index.tsx
+++ b/packages/react-cosmos-playground2/src/plugins/ResponsivePreview/ResponsivePreview/index.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 import styled from 'styled-components';
 import { Device, Viewport } from '../public';
 import { Header } from './Header';
-import { getAvailableViewport, getStyles, stretchStyle } from './style';
+import { getViewportScaleFactor, getStyles, stretchStyle } from './style';
 
 type Props = {
   children: React.ReactNode;
@@ -124,14 +124,6 @@ export class ResponsivePreview extends React.Component<Props, State> {
       });
     }
   }
-}
-
-function getViewportScaleFactor(viewport: Viewport, container: Viewport) {
-  const containerViewport = getAvailableViewport(container);
-  return Math.min(
-    Math.min(1, containerViewport.width / viewport.width),
-    Math.min(1, containerViewport.height / viewport.height)
-  );
 }
 
 function getContainerSize(containerEl: null | HTMLElement) {

--- a/packages/react-cosmos-playground2/src/plugins/ResponsivePreview/ResponsivePreview/index.tsx
+++ b/packages/react-cosmos-playground2/src/plugins/ResponsivePreview/ResponsivePreview/index.tsx
@@ -1,28 +1,29 @@
-import React from 'react';
 import { isEqual } from 'lodash';
+import React from 'react';
 import styled from 'styled-components';
+import { Device, Viewport } from '../public';
 import { Header } from './Header';
-import { stretchStyle, getStyles, getAvailableViewport } from './style';
-import { Viewport, Device } from '../public';
+import { getAvailableViewport, getStyles, stretchStyle } from './style';
 
 type Props = {
   children: React.ReactNode;
   devices: Device[];
-  viewport: null | Viewport;
+  enabled: boolean;
+  viewport: Viewport;
+  scaled: boolean;
   fullScreen: boolean;
   validFixtureSelected: boolean;
   setViewport(viewport: Viewport): unknown;
+  setScaled(scaled: boolean): unknown;
 };
 
 type State = {
   container: null | Viewport;
-  scaled: boolean;
 };
 
 export class ResponsivePreview extends React.Component<Props, State> {
   state: State = {
-    container: null,
-    scaled: true
+    container: null
   };
 
   containerEl: null | HTMLElement = null;
@@ -31,17 +32,19 @@ export class ResponsivePreview extends React.Component<Props, State> {
     const {
       children,
       devices,
+      enabled,
       viewport,
+      scaled,
       fullScreen,
       validFixtureSelected
     } = this.props;
-    const { container, scaled } = this.state;
+    const { container } = this.state;
 
     // We don't simply do `return children` because it would cause a flicker
     // whenever switching between responsive and non responsive mode. By
     // returning the same element nesting between states for Preview the
     // component instances are preserved and the transition is seamless.
-    if (!validFixtureSelected || fullScreen || !viewport || !container) {
+    if (!validFixtureSelected || fullScreen || !enabled || !container) {
       return (
         <Container>
           <div key="preview" ref={this.handleContainerRef} style={stretchStyle}>
@@ -109,7 +112,7 @@ export class ResponsivePreview extends React.Component<Props, State> {
   };
 
   toggleScale = () => {
-    this.setState(({ scaled }) => ({ scaled: !scaled }));
+    this.props.setScaled(!this.props.scaled);
   };
 
   updateContainerSize() {

--- a/packages/react-cosmos-playground2/src/plugins/ResponsivePreview/ResponsivePreview/style.ts
+++ b/packages/react-cosmos-playground2/src/plugins/ResponsivePreview/ResponsivePreview/style.ts
@@ -31,7 +31,18 @@ export function getStyles({
   };
 }
 
-export function getAvailableViewport(container: Viewport) {
+export function getViewportScaleFactor(
+  viewport: Viewport,
+  container: Viewport
+) {
+  const containerViewport = getAvailableViewport(container);
+  return Math.min(
+    Math.min(1, containerViewport.width / viewport.width),
+    Math.min(1, containerViewport.height / viewport.height)
+  );
+}
+
+function getAvailableViewport(container: Viewport) {
   return {
     width: container.width - getHorPadding(),
     height: container.height - getVerPadding()

--- a/packages/react-cosmos-playground2/src/plugins/ResponsivePreview/ResponsivePreview/style.ts
+++ b/packages/react-cosmos-playground2/src/plugins/ResponsivePreview/ResponsivePreview/style.ts
@@ -8,23 +8,23 @@ export const stretchStyle = { display: 'flex', flex: 1 };
 export function getStyles({
   container,
   viewport,
-  scale
+  scaled
 }: {
   container: Viewport;
   viewport: Viewport;
-  scale: boolean;
+  scaled: boolean;
 }) {
   const { width, height } = viewport;
 
   const availableViewport = getAvailableViewport(container);
   const widthScale = Math.min(1, availableViewport.width / width);
   const heightScale = Math.min(1, availableViewport.height / height);
-  const scaleFactor = scale ? Math.min(widthScale, heightScale) : 1;
+  const scaleFactor = scaled ? Math.min(widthScale, heightScale) : 1;
   const scaledWidth = width * scaleFactor;
   const scaledHeight = height * scaleFactor;
 
   return {
-    maskContainerStyle: getMaskContainerStyle(scale, widthScale, heightScale),
+    maskContainerStyle: getMaskContainerStyle(scaled, widthScale, heightScale),
     padContainerStyle: getPadContainerStyle(),
     alignContainerStyle: getAlignContainerStyle(scaledWidth, scaledHeight),
     scaleContainerStyle: getScaleContainerStyle(width, height, scaleFactor)

--- a/packages/react-cosmos-playground2/src/plugins/ResponsivePreview/ToggleButton/index.tsx
+++ b/packages/react-cosmos-playground2/src/plugins/ResponsivePreview/ToggleButton/index.tsx
@@ -4,13 +4,13 @@ import { IconButton } from '../../../shared/ui/buttons';
 
 type Props = {
   validFixtureSelected: boolean;
-  responsiveModeOn: boolean;
+  enabled: boolean;
   toggleViewportState: () => unknown;
 };
 
 export function ToggleButton({
   validFixtureSelected,
-  responsiveModeOn,
+  enabled,
   toggleViewportState
 }: Props) {
   if (!validFixtureSelected) {
@@ -27,7 +27,7 @@ export function ToggleButton({
     <IconButton
       icon={<SmartphoneIcon />}
       title="Toggle responsive mode"
-      selected={responsiveModeOn}
+      selected={enabled}
       onClick={toggleViewportState}
     />
   );

--- a/packages/react-cosmos-playground2/src/plugins/ResponsivePreview/__tests__/enabled.tsx
+++ b/packages/react-cosmos-playground2/src/plugins/ResponsivePreview/__tests__/enabled.tsx
@@ -166,6 +166,7 @@ it('saves viewport in storage on device select', async () => {
 
   expect(storageMock[VIEWPORT_STORAGE_KEY]).toEqual({
     enabled: true,
+    scaled: true,
     viewport: { width: 414, height: 736 }
   });
 });

--- a/packages/react-cosmos-playground2/src/plugins/ResponsivePreview/__tests__/enabled.tsx
+++ b/packages/react-cosmos-playground2/src/plugins/ResponsivePreview/__tests__/enabled.tsx
@@ -133,7 +133,7 @@ it('renders responsive device labels', async () => {
 
   const renderer = loadTestPlugins();
   for (const device of DEFAULT_DEVICES) {
-    renderer.getByText(device.label);
+    renderer.getByText(device.label, { selector: 'option' });
   }
 });
 

--- a/packages/react-cosmos-playground2/src/plugins/ResponsivePreview/__tests__/enabled.tsx
+++ b/packages/react-cosmos-playground2/src/plugins/ResponsivePreview/__tests__/enabled.tsx
@@ -183,7 +183,7 @@ it('clears viewport in fixture state on untoggle', async () => {
   expect(mocks.fixtureState.viewport).toEqual(null);
 });
 
-it('clears storage viewport state on untoggle', async () => {
+it('sets disabled viewport state on untoggle', async () => {
   register();
   const storageMock = mockEnabledViewportStorage();
   mockRouter({ isFullScreen: () => false });

--- a/packages/react-cosmos-playground2/src/plugins/ResponsivePreview/__tests__/enabled.tsx
+++ b/packages/react-cosmos-playground2/src/plugins/ResponsivePreview/__tests__/enabled.tsx
@@ -32,18 +32,12 @@ function loadTestPlugins() {
   );
 }
 
-async function waitForMainPlug({ getByTestId }: RenderResult) {
-  await waitForElement(() => getByTestId('responsivePreview'));
-}
-
 async function toggleResponsiveMode({ getByTitle }: RenderResult) {
-  fireEvent.click(
-    await waitForElement(() => getByTitle(/toggle responsive mode/i))
-  );
+  fireEvent.click(getByTitle(/toggle responsive mode/i));
 }
 
-async function selectViewport({ getByText }: RenderResult, match: RegExp) {
-  fireEvent.click(await waitForElement(() => getByText(match)));
+async function selectViewport({ getByTestId }: RenderResult, value: string) {
+  fireEvent.change(getByTestId('viewportSelect'), { target: { value } });
 }
 
 it('renders children of "rendererPreviewOuter" slot', async () => {
@@ -70,7 +64,6 @@ it('does not render responsive header when no fixture is selected', async () => 
   });
 
   const renderer = loadTestPlugins();
-  await waitForMainPlug(renderer);
   expect(renderer.queryByTestId('responsiveHeader')).toBeNull();
 });
 
@@ -84,7 +77,6 @@ it('does not render responsive header in full screen mode', async () => {
   });
 
   const renderer = loadTestPlugins();
-  await waitForMainPlug(renderer);
   expect(renderer.queryByTestId('responsiveHeader')).toBeNull();
 });
 
@@ -135,7 +127,7 @@ describe('on device select', () => {
 
     const renderer = loadTestPlugins();
     await toggleResponsiveMode(renderer);
-    await selectViewport(renderer, /iphone 6\+/i);
+    await selectViewport(renderer, '414x736');
 
     await wait(() =>
       expect((fixtureState as FixtureStateWithViewport).viewport).toEqual({
@@ -163,7 +155,7 @@ describe('on device select', () => {
 
     const renderer = loadTestPlugins();
     await toggleResponsiveMode(renderer);
-    await selectViewport(renderer, /iphone 6\+/i);
+    await selectViewport(renderer, '414x736');
 
     await wait(() =>
       expect(storage[STORAGE_KEY]).toEqual({ width: 414, height: 736 })
@@ -187,7 +179,7 @@ it('clears viewport in fixture state on untoggle', async () => {
 
   const renderer = loadTestPlugins();
   await toggleResponsiveMode(renderer);
-  await selectViewport(renderer, /iphone 6\+/i);
+  await selectViewport(renderer, '414x736');
   await toggleResponsiveMode(renderer);
 
   await wait(() =>

--- a/packages/react-cosmos-playground2/src/plugins/ResponsivePreview/__tests__/fixtureViewport.tsx
+++ b/packages/react-cosmos-playground2/src/plugins/ResponsivePreview/__tests__/fixtureViewport.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render, waitForElement } from '@testing-library/react';
+import { render } from '@testing-library/react';
 import { loadPlugins, Slot } from 'react-plugin';
 import { cleanup } from '../../../testHelpers/plugin';
 import {
@@ -40,5 +40,5 @@ it('renders responsive header', async () => {
   registerTestPlugins();
 
   const { getByTestId } = loadTestPlugins();
-  await waitForElement(() => getByTestId('responsiveHeader'));
+  getByTestId('responsiveHeader');
 });

--- a/packages/react-cosmos-playground2/src/plugins/ResponsivePreview/__tests__/noFixtureSelected.tsx
+++ b/packages/react-cosmos-playground2/src/plugins/ResponsivePreview/__tests__/noFixtureSelected.tsx
@@ -1,10 +1,5 @@
 import React from 'react';
-import {
-  render,
-  waitForElement,
-  RenderResult,
-  wait
-} from '@testing-library/react';
+import { render } from '@testing-library/react';
 import { loadPlugins, Slot, ArraySlot } from 'react-plugin';
 import { cleanup } from '../../../testHelpers/plugin';
 import { register } from '..';
@@ -40,27 +35,21 @@ function loadTestPlugins() {
   );
 }
 
-async function waitForMainPlug({ getByTestId }: RenderResult) {
-  await waitForElement(() => getByTestId('responsivePreview'));
-}
-
 it('renders disabled button', async () => {
   registerTestPlugins();
   const { getByTitle } = loadTestPlugins();
-  await wait(() =>
-    expect(getByTitle(/toggle responsive mode/i)).toHaveAttribute('disabled')
-  );
+  expect(getByTitle(/toggle responsive mode/i)).toHaveAttribute('disabled');
 });
 
 it('renders children of "rendererPreviewOuter" slot', async () => {
   registerTestPlugins();
   const { getByTestId } = loadTestPlugins();
-  await waitForElement(() => getByTestId('previewMock'));
+  getByTestId('previewMock');
 });
 
 it('does not render responsive header', async () => {
   registerTestPlugins();
   const renderer = loadTestPlugins();
-  await waitForMainPlug(renderer);
+  renderer.getByTestId('responsivePreview');
   expect(renderer.queryByTestId('responsiveHeader')).toBeNull();
 });

--- a/packages/react-cosmos-playground2/src/plugins/ResponsivePreview/index.tsx
+++ b/packages/react-cosmos-playground2/src/plugins/ResponsivePreview/index.tsx
@@ -32,7 +32,7 @@ plug('rendererPreviewOuter', ({ children, pluginContext }) => {
   return (
     <ResponsivePreview
       devices={devices}
-      enabled={Boolean(fixtureState.viewport) || viewportState.enabled}
+      enabled={fixtureState.viewport ? true : viewportState.enabled}
       viewport={fixtureState.viewport || viewportState.viewport}
       scaled={viewportState.scaled}
       fullScreen={router.isFullScreen()}
@@ -59,14 +59,14 @@ namedPlug('rendererAction', 'responsivePreview', ({ pluginContext }) => {
   const rendererCore = getMethodsOf<RendererCoreSpec>('rendererCore');
   const fixtureState = rendererCore.getFixtureState();
   const viewportState = getViewportState(pluginContext);
-  const responsiveModeOn = fixtureState.viewport ? true : viewportState.enabled;
+  const enabled = fixtureState.viewport ? true : viewportState.enabled;
 
   return (
     <ToggleButton
       validFixtureSelected={rendererCore.isValidFixtureSelected()}
-      responsiveModeOn={responsiveModeOn}
+      enabled={enabled}
       toggleViewportState={() => {
-        if (responsiveModeOn) {
+        if (enabled) {
           setViewportState(pluginContext, { ...viewportState, enabled: false });
           setFixtureStateViewport(pluginContext, null);
         } else {

--- a/packages/react-cosmos-playground2/src/plugins/ResponsivePreview/index.tsx
+++ b/packages/react-cosmos-playground2/src/plugins/ResponsivePreview/index.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import { createPlugin } from 'react-plugin';
-import { FixtureState } from 'react-cosmos-shared2/fixtureState';
 import { StorageSpec } from '../Storage/public';
 import { RendererCoreSpec } from '../RendererCore/public';
 import { RouterSpec } from '../Router/public';
@@ -8,8 +7,9 @@ import { ResponsivePreviewSpec, Viewport } from './public';
 import {
   Context,
   DEFAULT_DEVICES,
-  DEFAULT_VIEWPORT,
-  STORAGE_KEY
+  VIEWPORT_STORAGE_KEY,
+  DEFAULT_VIEWPORT_STATE,
+  ViewportState
 } from './shared';
 import { ResponsivePreview } from './ResponsivePreview';
 import { ToggleButton } from './ToggleButton';
@@ -18,23 +18,19 @@ const { plug, namedPlug, register } = createPlugin<ResponsivePreviewSpec>({
   name: 'responsivePreview',
   defaultConfig: {
     devices: DEFAULT_DEVICES
-  },
-  initialState: {
-    enabled: false,
-    viewport: null
   }
 });
 
 plug('rendererPreviewOuter', ({ children, pluginContext }) => {
-  const { getConfig, getState, setState, getMethodsOf } = pluginContext;
+  const { getConfig, getMethodsOf } = pluginContext;
   const { devices } = getConfig();
-  const { enabled } = getState();
-  const storage = getMethodsOf<StorageSpec>('storage');
   const router = getMethodsOf<RouterSpec>('router');
   const rendererCore = getMethodsOf<RendererCoreSpec>('rendererCore');
   const fixtureState = rendererCore.getFixtureState();
+  const viewportState = getViewportState(pluginContext);
   const viewport =
-    fixtureState.viewport || getActiveViewport(pluginContext, enabled);
+    fixtureState.viewport ||
+    (viewportState.enabled ? viewportState.viewport : null);
 
   return (
     <ResponsivePreview
@@ -43,9 +39,11 @@ plug('rendererPreviewOuter', ({ children, pluginContext }) => {
       fullScreen={router.isFullScreen()}
       validFixtureSelected={rendererCore.isValidFixtureSelected()}
       setViewport={(newViewport: Viewport) => {
-        storage.setItem(STORAGE_KEY, newViewport);
+        setViewportState(pluginContext, {
+          enabled: true,
+          viewport: newViewport
+        });
         setFixtureStateViewport(pluginContext, newViewport);
-        setState({ enabled: true, viewport: newViewport });
       }}
     >
       {children}
@@ -54,23 +52,24 @@ plug('rendererPreviewOuter', ({ children, pluginContext }) => {
 });
 
 namedPlug('rendererAction', 'responsivePreview', ({ pluginContext }) => {
-  const { getState, setState, getMethodsOf } = pluginContext;
-  const { enabled } = getState();
+  const { getMethodsOf } = pluginContext;
   const rendererCore = getMethodsOf<RendererCoreSpec>('rendererCore');
   const fixtureState = rendererCore.getFixtureState();
-  const responsiveModeOn = isResponsiveModeOn(enabled, fixtureState);
+  const viewportState = getViewportState(pluginContext);
+  const responsiveModeOn = fixtureState.viewport ? true : viewportState.enabled;
 
   return (
     <ToggleButton
       validFixtureSelected={rendererCore.isValidFixtureSelected()}
       responsiveModeOn={responsiveModeOn}
       toggleViewportState={() => {
-        const nextEnabled = !responsiveModeOn;
-        setState(prevState => ({ ...prevState, enabled: nextEnabled }));
-        setFixtureStateViewport(
-          pluginContext,
-          getActiveViewport(pluginContext, nextEnabled)
-        );
+        if (responsiveModeOn) {
+          setViewportState(pluginContext, { ...viewportState, enabled: false });
+          setFixtureStateViewport(pluginContext, null);
+        } else {
+          setViewportState(pluginContext, { ...viewportState, enabled: true });
+          setFixtureStateViewport(pluginContext, viewportState.viewport);
+        }
       }}
     />
   );
@@ -78,21 +77,20 @@ namedPlug('rendererAction', 'responsivePreview', ({ pluginContext }) => {
 
 export { register };
 
-function getActiveViewport(context: Context, responsiveModeEnabled: boolean) {
+function getViewportState(context: Context): ViewportState {
   const storage = context.getMethodsOf<StorageSpec>('storage');
-  return responsiveModeEnabled
-    ? storage.getItem<Viewport>(STORAGE_KEY) || DEFAULT_VIEWPORT
-    : null;
+  return (
+    storage.getItem<ViewportState>(VIEWPORT_STORAGE_KEY) ||
+    DEFAULT_VIEWPORT_STATE
+  );
+}
+
+function setViewportState(context: Context, viewportState: ViewportState) {
+  const storage = context.getMethodsOf<StorageSpec>('storage');
+  storage.setItem(VIEWPORT_STORAGE_KEY, viewportState);
 }
 
 function setFixtureStateViewport(context: Context, viewport: null | Viewport) {
   const rendererCore = context.getMethodsOf<RendererCoreSpec>('rendererCore');
   rendererCore.setFixtureState(fixtureState => ({ ...fixtureState, viewport }));
-}
-
-function isResponsiveModeOn(
-  responsiveModeEnabled: boolean,
-  fixtureState: FixtureState
-): boolean {
-  return fixtureState.viewport ? true : responsiveModeEnabled;
 }

--- a/packages/react-cosmos-playground2/src/plugins/ResponsivePreview/index.tsx
+++ b/packages/react-cosmos-playground2/src/plugins/ResponsivePreview/index.tsx
@@ -28,23 +28,26 @@ plug('rendererPreviewOuter', ({ children, pluginContext }) => {
   const rendererCore = getMethodsOf<RendererCoreSpec>('rendererCore');
   const fixtureState = rendererCore.getFixtureState();
   const viewportState = getViewportState(pluginContext);
-  const viewport =
-    fixtureState.viewport ||
-    (viewportState.enabled ? viewportState.viewport : null);
 
   return (
     <ResponsivePreview
       devices={devices}
-      viewport={viewport}
+      enabled={Boolean(fixtureState.viewport) || viewportState.enabled}
+      viewport={fixtureState.viewport || viewportState.viewport}
+      scaled={viewportState.scaled}
       fullScreen={router.isFullScreen()}
       validFixtureSelected={rendererCore.isValidFixtureSelected()}
-      setViewport={(newViewport: Viewport) => {
+      setViewport={newViewport => {
         setViewportState(pluginContext, {
+          ...viewportState,
           enabled: true,
           viewport: newViewport
         });
         setFixtureStateViewport(pluginContext, newViewport);
       }}
+      setScaled={scaled =>
+        setViewportState(pluginContext, { ...viewportState, scaled })
+      }
     >
       {children}
     </ResponsivePreview>

--- a/packages/react-cosmos-playground2/src/plugins/ResponsivePreview/public.ts
+++ b/packages/react-cosmos-playground2/src/plugins/ResponsivePreview/public.ts
@@ -9,8 +9,4 @@ export type ResponsivePreviewSpec = {
   config: {
     devices: Device[];
   };
-  state: {
-    enabled: boolean;
-    viewport: null | Viewport;
-  };
 };

--- a/packages/react-cosmos-playground2/src/plugins/ResponsivePreview/shared.ts
+++ b/packages/react-cosmos-playground2/src/plugins/ResponsivePreview/shared.ts
@@ -8,6 +8,7 @@ export type StorageMethods = StorageSpec['methods'];
 
 export type ViewportState = {
   enabled: boolean;
+  scaled: boolean;
   viewport: Viewport;
 };
 
@@ -24,5 +25,6 @@ export const VIEWPORT_STORAGE_KEY = 'responsiveViewportState';
 
 export const DEFAULT_VIEWPORT_STATE: ViewportState = {
   enabled: false,
+  scaled: true,
   viewport: { width: 320, height: 568 }
 };

--- a/packages/react-cosmos-playground2/src/plugins/ResponsivePreview/shared.ts
+++ b/packages/react-cosmos-playground2/src/plugins/ResponsivePreview/shared.ts
@@ -1,10 +1,15 @@
 import { PluginContext } from 'react-plugin';
 import { StorageSpec } from '../Storage/public';
-import { ResponsivePreviewSpec } from './public';
+import { ResponsivePreviewSpec, Viewport } from './public';
 
 export type Context = PluginContext<ResponsivePreviewSpec>;
 
 export type StorageMethods = StorageSpec['methods'];
+
+export type ViewportState = {
+  enabled: boolean;
+  viewport: Viewport;
+};
 
 export const DEFAULT_DEVICES = [
   { label: 'iPhone 5', width: 320, height: 568 },
@@ -15,9 +20,9 @@ export const DEFAULT_DEVICES = [
   { label: '1080p', width: 1920, height: 1080 }
 ];
 
-export const DEFAULT_VIEWPORT = {
-  width: 320,
-  height: 568
-};
+export const VIEWPORT_STORAGE_KEY = 'responsiveViewportState';
 
-export const STORAGE_KEY = 'responsiveViewport';
+export const DEFAULT_VIEWPORT_STATE: ViewportState = {
+  enabled: false,
+  viewport: { width: 320, height: 568 }
+};

--- a/packages/react-cosmos-playground2/src/shared/ui/inputs/NumberInput.tsx
+++ b/packages/react-cosmos-playground2/src/shared/ui/inputs/NumberInput.tsx
@@ -1,0 +1,64 @@
+import React from 'react';
+import { KEY_DOWN, KEY_UP } from '../../keys';
+import {
+  TextContainer,
+  TextField,
+  TextInputContainer,
+  TextMirror
+} from './shared';
+
+type Props = {
+  id: string;
+  value: number;
+  onChange: (newValue: number) => unknown;
+};
+
+export function NumberInput({ id, value, onChange }: Props) {
+  const [focused, setFocused] = React.useState(false);
+  const onFocus = React.useCallback(() => setFocused(true), []);
+  const onBlur = React.useCallback(() => setFocused(false), []);
+
+  const onInputChange = React.useCallback(
+    (e: React.SyntheticEvent<HTMLTextAreaElement>) => {
+      const newValue = +e.currentTarget.value;
+      if (isFinite(newValue)) {
+        onChange(newValue);
+      }
+    },
+    [onChange]
+  );
+
+  const onKeyDown = React.useCallback(
+    (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
+      switch (e.keyCode) {
+        case KEY_UP:
+          e.preventDefault();
+          return onChange(value + 1);
+        case KEY_DOWN:
+          e.preventDefault();
+          return onChange(value - 1);
+        default:
+        // Nada
+      }
+    },
+    [value, onChange]
+  );
+
+  return (
+    <TextInputContainer focused={focused}>
+      <TextContainer>
+        <TextMirror style={{ opacity: focused ? 0 : 1 }}>{value}</TextMirror>
+        <TextField
+          rows={1}
+          id={id}
+          value={value}
+          onChange={onInputChange}
+          onFocus={onFocus}
+          onBlur={onBlur}
+          onKeyDown={onKeyDown}
+          style={{ opacity: focused ? 1 : 0 }}
+        />
+      </TextContainer>
+    </TextInputContainer>
+  );
+}

--- a/packages/react-cosmos-playground2/src/shared/ui/inputs/NumberInput.tsx
+++ b/packages/react-cosmos-playground2/src/shared/ui/inputs/NumberInput.tsx
@@ -15,7 +15,7 @@ type Styles = {
 };
 
 type Props = {
-  id: string;
+  id?: string;
   value: number;
   minValue?: number;
   maxValue?: number;

--- a/packages/react-cosmos-playground2/src/shared/ui/inputs/NumberInput.tsx
+++ b/packages/react-cosmos-playground2/src/shared/ui/inputs/NumberInput.tsx
@@ -7,11 +7,18 @@ import {
   TextMirror
 } from './shared';
 
+type Styles = {
+  focusedColor: string;
+  focusedBg: string;
+  focusedBoxShadow: string;
+};
+
 type Props = {
   id: string;
   value: number;
   minValue?: number;
   maxValue?: number;
+  styles: Styles;
   onChange: (newValue: number) => unknown;
 };
 
@@ -21,6 +28,7 @@ export function NumberInput({
   value,
   minValue = -Infinity,
   maxValue = Infinity,
+  styles,
   onChange
 }: Props) {
   const [focused, setFocused] = React.useState(false);
@@ -63,7 +71,11 @@ export function NumberInput({
   );
 
   return (
-    <TextInputContainer focused={focused}>
+    <TextInputContainer
+      focused={focused}
+      focusedBg={styles.focusedBg}
+      focusedBoxShadow={styles.focusedBoxShadow}
+    >
       <TextContainer>
         <TextMirror minWidth={8} focused={focused}>
           {value}
@@ -72,11 +84,12 @@ export function NumberInput({
           rows={1}
           id={id}
           value={value}
+          focused={focused}
+          color={styles.focusedColor}
           onChange={onInputChange}
           onFocus={onFocus}
           onBlur={onBlur}
           onKeyDown={onKeyDown}
-          style={{ opacity: focused ? 1 : 0 }}
         />
       </TextContainer>
     </TextInputContainer>

--- a/packages/react-cosmos-playground2/src/shared/ui/inputs/NumberInput.tsx
+++ b/packages/react-cosmos-playground2/src/shared/ui/inputs/NumberInput.tsx
@@ -65,7 +65,9 @@ export function NumberInput({
   return (
     <TextInputContainer focused={focused}>
       <TextContainer>
-        <TextMirror style={{ opacity: focused ? 0 : 1 }}>{value}</TextMirror>
+        <TextMirror minWidth={8} focused={focused}>
+          {value}
+        </TextMirror>
         <TextField
           rows={1}
           id={id}

--- a/packages/react-cosmos-playground2/src/shared/ui/inputs/NumberInput.tsx
+++ b/packages/react-cosmos-playground2/src/shared/ui/inputs/NumberInput.tsx
@@ -4,7 +4,8 @@ import {
   TextContainer,
   TextField,
   TextInputContainer,
-  TextMirror
+  TextMirror,
+  useFocus
 } from './shared';
 
 type Styles = {
@@ -31,9 +32,7 @@ export function NumberInput({
   styles,
   onChange
 }: Props) {
-  const [focused, setFocused] = React.useState(false);
-  const onFocus = React.useCallback(() => setFocused(true), []);
-  const onBlur = React.useCallback(() => setFocused(false), []);
+  const { focused, onFocus, onBlur } = useFocus();
 
   const trimValue = React.useCallback(
     (rawValue: number) => {

--- a/packages/react-cosmos-playground2/src/shared/ui/inputs/NumberInput.tsx
+++ b/packages/react-cosmos-playground2/src/shared/ui/inputs/NumberInput.tsx
@@ -45,7 +45,7 @@ export function NumberInput({
   );
 
   const onInputChange = React.useCallback(
-    (e: React.SyntheticEvent<HTMLTextAreaElement>) => {
+    (e: React.ChangeEvent<HTMLTextAreaElement>) => {
       const newValue = +e.currentTarget.value;
       if (isFinite(newValue)) {
         onChange(trimValue(newValue));

--- a/packages/react-cosmos-playground2/src/shared/ui/inputs/NumberInput.tsx
+++ b/packages/react-cosmos-playground2/src/shared/ui/inputs/NumberInput.tsx
@@ -10,22 +10,39 @@ import {
 type Props = {
   id: string;
   value: number;
+  minValue?: number;
+  maxValue?: number;
   onChange: (newValue: number) => unknown;
 };
 
-export function NumberInput({ id, value, onChange }: Props) {
+export function NumberInput({
+  id,
+  value,
+  minValue = -Infinity,
+  maxValue = Infinity,
+  onChange
+}: Props) {
   const [focused, setFocused] = React.useState(false);
   const onFocus = React.useCallback(() => setFocused(true), []);
   const onBlur = React.useCallback(() => setFocused(false), []);
+
+  const trimValue = React.useCallback(
+    (rawValue: number) => {
+      let validValue = Math.min(maxValue, rawValue);
+      validValue = Math.max(minValue, validValue);
+      return validValue;
+    },
+    [maxValue, minValue]
+  );
 
   const onInputChange = React.useCallback(
     (e: React.SyntheticEvent<HTMLTextAreaElement>) => {
       const newValue = +e.currentTarget.value;
       if (isFinite(newValue)) {
-        onChange(newValue);
+        onChange(trimValue(newValue));
       }
     },
-    [onChange]
+    [onChange, trimValue]
   );
 
   const onKeyDown = React.useCallback(
@@ -33,15 +50,15 @@ export function NumberInput({ id, value, onChange }: Props) {
       switch (e.keyCode) {
         case KEY_UP:
           e.preventDefault();
-          return onChange(value + 1);
+          return onChange(trimValue(value + 1));
         case KEY_DOWN:
           e.preventDefault();
-          return onChange(value - 1);
+          return onChange(trimValue(value - 1));
         default:
         // Nada
       }
     },
-    [value, onChange]
+    [onChange, trimValue, value]
   );
 
   return (

--- a/packages/react-cosmos-playground2/src/shared/ui/inputs/NumberInput.tsx
+++ b/packages/react-cosmos-playground2/src/shared/ui/inputs/NumberInput.tsx
@@ -15,6 +15,7 @@ type Props = {
   onChange: (newValue: number) => unknown;
 };
 
+// TODO: Support decimals
 export function NumberInput({
   id,
   value,

--- a/packages/react-cosmos-playground2/src/shared/ui/inputs/Select.tsx
+++ b/packages/react-cosmos-playground2/src/shared/ui/inputs/Select.tsx
@@ -1,4 +1,6 @@
 import React from 'react';
+import styled from 'styled-components';
+import { ChevronDownIcon } from '../../icons';
 import { useFocus } from './shared';
 
 type BaseOption = { value: string; label: string };
@@ -18,7 +20,7 @@ export function Select<Option extends BaseOption>({
   value,
   onChange
 }: Props<Option>) {
-  const { onFocus, onBlur } = useFocus();
+  const { focused, onFocus, onBlur } = useFocus();
 
   const onInputChange = React.useCallback(
     (e: React.ChangeEvent<HTMLSelectElement>) => {
@@ -31,23 +33,76 @@ export function Select<Option extends BaseOption>({
     [onChange, options]
   );
 
+  const selectedOption = options.find(o => o.value === value);
+  const selectedLabel = selectedOption ? selectedOption.label : 'Custom';
   return (
-    <select
-      id={id}
-      data-testid={testId}
-      value={value}
-      onFocus={onFocus}
-      onBlur={onBlur}
-      onChange={onInputChange}
-    >
-      {options.map((option, idx) => {
-        const isSelected = value === option.value;
-        return (
-          <option key={idx} value={option.value} disabled={isSelected}>
-            {option.label}
-          </option>
-        );
-      })}
-    </select>
+    <Container focused={focused}>
+      <VisibleButton>
+        <Label>{selectedLabel}</Label>
+        <IconContainer>
+          <ChevronDownIcon />
+        </IconContainer>
+      </VisibleButton>
+      <SelectInput
+        id={id}
+        data-testid={testId}
+        value={value}
+        onFocus={onFocus}
+        onBlur={onBlur}
+        onChange={onInputChange}
+      >
+        {options.map((option, idx) => {
+          const isSelected = value === option.value;
+          return (
+            <option key={idx} value={option.value} disabled={isSelected}>
+              {option.label}
+            </option>
+          );
+        })}
+      </SelectInput>
+    </Container>
   );
 }
+
+const Container = styled.div<{ focused: boolean }>`
+  position: relative;
+  border-radius: 3px;
+  box-shadow: ${props =>
+    props.focused ? '0 0 1px 1px var(--primary4)' : 'none'};
+
+  :hover {
+    background: hsl(var(--hue-primary), 25%, 95%);
+  }
+`;
+
+const VisibleButton = styled.div`
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  padding: 0 6px 0 8px;
+  height: 32px;
+`;
+
+export const Label = styled.span`
+  color: var(--grey2);
+  line-height: 32px;
+`;
+
+export const IconContainer = styled.span`
+  --size: 16px;
+  width: var(--size);
+  height: var(--size);
+  padding: 2px 0 0 2px;
+  color: var(--grey3);
+`;
+
+const SelectInput = styled.select`
+  position: absolute;
+  z-index: 1;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  outline: none;
+  opacity: 0;
+`;

--- a/packages/react-cosmos-playground2/src/shared/ui/inputs/Select.tsx
+++ b/packages/react-cosmos-playground2/src/shared/ui/inputs/Select.tsx
@@ -1,0 +1,53 @@
+import React from 'react';
+import { useFocus } from './shared';
+
+type BaseOption = { value: string; label: string };
+
+type Props<Option extends BaseOption> = {
+  id?: string;
+  testId?: string;
+  options: Option[];
+  value: string;
+  onChange: (newValue: Option) => unknown;
+};
+
+export function Select<Option extends BaseOption>({
+  id,
+  testId,
+  options,
+  value,
+  onChange
+}: Props<Option>) {
+  const { onFocus, onBlur } = useFocus();
+
+  const onInputChange = React.useCallback(
+    (e: React.ChangeEvent<HTMLSelectElement>) => {
+      const option = options.find(o => o.value === e.target.value);
+      if (!option) {
+        throw new Error(`Select value doesn't match any option`);
+      }
+      onChange(option);
+    },
+    [onChange, options]
+  );
+
+  return (
+    <select
+      id={id}
+      data-testid={testId}
+      value={value}
+      onFocus={onFocus}
+      onBlur={onBlur}
+      onChange={onInputChange}
+    >
+      {options.map((option, idx) => {
+        const isSelected = value === option.value;
+        return (
+          <option key={idx} value={option.value} disabled={isSelected}>
+            {option.label}
+          </option>
+        );
+      })}
+    </select>
+  );
+}

--- a/packages/react-cosmos-playground2/src/shared/ui/inputs/shared.tsx
+++ b/packages/react-cosmos-playground2/src/shared/ui/inputs/shared.tsx
@@ -1,4 +1,12 @@
+import React from 'react';
 import styled from 'styled-components';
+
+export function useFocus() {
+  const [focused, setFocused] = React.useState(false);
+  const onFocus = React.useCallback(() => setFocused(true), []);
+  const onBlur = React.useCallback(() => setFocused(false), []);
+  return { focused, onFocus, onBlur };
+}
 
 export const TextInputContainer = styled.div<{
   focused: boolean;

--- a/packages/react-cosmos-playground2/src/shared/ui/inputs/shared.tsx
+++ b/packages/react-cosmos-playground2/src/shared/ui/inputs/shared.tsx
@@ -1,0 +1,40 @@
+import styled from 'styled-components';
+
+export const TextInputContainer = styled.div<{ focused: boolean }>`
+  box-sizing: border-box;
+  max-width: 100%;
+  padding: 2px 4px;
+  border-radius: 3px;
+  background: ${props => (props.focused ? 'var(--grey1)' : 'transparent')};
+  box-shadow: ${props =>
+    props.focused ? '0 0 0.5px 1px var(--primary4)' : 'none'};
+`;
+
+export const TextContainer = styled.div`
+  position: relative;
+`;
+
+export const TextField = styled.textarea`
+  position: absolute;
+  z-index: 1;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  border: 0;
+  background: none;
+  color: var(--grey7);
+  line-height: 20px;
+  white-space: pre;
+  overflow: hidden;
+  outline: none;
+  resize: none;
+`;
+
+export const TextMirror = styled.div`
+  min-height: 20px;
+  line-height: 20px;
+  white-space: pre;
+  overflow: hidden;
+  text-overflow: ellipsis;
+`;

--- a/packages/react-cosmos-playground2/src/shared/ui/inputs/shared.tsx
+++ b/packages/react-cosmos-playground2/src/shared/ui/inputs/shared.tsx
@@ -31,7 +31,9 @@ export const TextField = styled.textarea`
   resize: none;
 `;
 
-export const TextMirror = styled.div`
+export const TextMirror = styled.div<{ focused: boolean; minWidth: number }>`
+  opacity: ${props => (props.focused ? 0 : 1)};
+  min-width: ${props => props.minWidth}px;
   min-height: 20px;
   line-height: 20px;
   white-space: pre;

--- a/packages/react-cosmos-playground2/src/shared/ui/inputs/shared.tsx
+++ b/packages/react-cosmos-playground2/src/shared/ui/inputs/shared.tsx
@@ -1,20 +1,23 @@
 import styled from 'styled-components';
 
-export const TextInputContainer = styled.div<{ focused: boolean }>`
+export const TextInputContainer = styled.div<{
+  focused: boolean;
+  focusedBg: string;
+  focusedBoxShadow: string;
+}>`
   box-sizing: border-box;
   max-width: 100%;
   padding: 2px 4px;
   border-radius: 3px;
-  background: ${props => (props.focused ? 'var(--grey1)' : 'transparent')};
-  box-shadow: ${props =>
-    props.focused ? '0 0 0.5px 1px var(--primary4)' : 'none'};
+  background: ${props => (props.focused ? props.focusedBg : 'transparent')};
+  box-shadow: ${props => (props.focused ? props.focusedBoxShadow : 'none')};
 `;
 
 export const TextContainer = styled.div`
   position: relative;
 `;
 
-export const TextField = styled.textarea`
+export const TextField = styled.textarea<{ focused: boolean; color: string }>`
   position: absolute;
   z-index: 1;
   top: 0;
@@ -23,12 +26,13 @@ export const TextField = styled.textarea`
   height: 100%;
   border: 0;
   background: none;
-  color: var(--grey7);
+  color: ${props => props.color};
   line-height: 20px;
   white-space: pre;
   overflow: hidden;
   outline: none;
   resize: none;
+  opacity: ${props => (props.focused ? 1 : 0)};
 `;
 
 export const TextMirror = styled.div<{ focused: boolean; minWidth: number }>`

--- a/packages/react-cosmos-playground2/src/shared/ui/valueInputTree/ValueInputTreeItem/BooleanItem.tsx
+++ b/packages/react-cosmos-playground2/src/shared/ui/valueInputTree/ValueInputTreeItem/BooleanItem.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import styled from 'styled-components';
-import { Label, ValueContainer } from './shared';
+import { ValueContainer, Label } from './shared';
 
 type Props = {
   id: string;

--- a/packages/react-cosmos-playground2/src/shared/ui/valueInputTree/ValueInputTreeItem/BooleanItem.tsx
+++ b/packages/react-cosmos-playground2/src/shared/ui/valueInputTree/ValueInputTreeItem/BooleanItem.tsx
@@ -9,19 +9,16 @@ type Props = {
   onChange: (newValue: boolean) => unknown;
 };
 
-export function BooleanInput({ id, label, value, onChange }: Props) {
-  const onInputToggle = React.useCallback(() => onChange(!value), [
-    onChange,
-    value
-  ]);
+export function BooleanItem({ id, label, value, onChange }: Props) {
+  const onToggle = React.useCallback(() => onChange(!value), [onChange, value]);
 
   return (
     <>
-      <Label title={label} as="span" onClick={onInputToggle}>
+      <Label title={label} as="span" onClick={onToggle}>
         {label}
       </Label>
       <ValueContainer>
-        <BooleanButton onClick={onInputToggle}>
+        <BooleanButton onClick={onToggle}>
           {value ? 'true' : 'false'}
         </BooleanButton>
       </ValueContainer>

--- a/packages/react-cosmos-playground2/src/shared/ui/valueInputTree/ValueInputTreeItem/NullItem.tsx
+++ b/packages/react-cosmos-playground2/src/shared/ui/valueInputTree/ValueInputTreeItem/NullItem.tsx
@@ -6,7 +6,7 @@ type Props = {
   label: string;
 };
 
-export function NullInput({ id, label }: Props) {
+export function NullItem({ id, label }: Props) {
   return (
     <>
       <Label title={label} htmlFor={id}>

--- a/packages/react-cosmos-playground2/src/shared/ui/valueInputTree/ValueInputTreeItem/NullItem.tsx
+++ b/packages/react-cosmos-playground2/src/shared/ui/valueInputTree/ValueInputTreeItem/NullItem.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Label, ValueContainer, UneditableInput } from './shared';
+import { ValueContainer, Label, UneditableInput } from './shared';
 
 type Props = {
   id: string;

--- a/packages/react-cosmos-playground2/src/shared/ui/valueInputTree/ValueInputTreeItem/NumberItem.tsx
+++ b/packages/react-cosmos-playground2/src/shared/ui/valueInputTree/ValueInputTreeItem/NumberItem.tsx
@@ -16,7 +16,16 @@ export function NumberItem({ id, label, value, onChange }: Props) {
         {label}
       </Label>
       <ValueContainer>
-        <NumberInput id={id} value={value} onChange={onChange} />
+        <NumberInput
+          id={id}
+          value={value}
+          styles={{
+            focusedColor: 'var(--grey7)',
+            focusedBg: 'var(--grey1)',
+            focusedBoxShadow: '0 0 0.5px 1px var(--primary4)'
+          }}
+          onChange={onChange}
+        />
       </ValueContainer>
     </>
   );

--- a/packages/react-cosmos-playground2/src/shared/ui/valueInputTree/ValueInputTreeItem/NumberItem.tsx
+++ b/packages/react-cosmos-playground2/src/shared/ui/valueInputTree/ValueInputTreeItem/NumberItem.tsx
@@ -1,13 +1,6 @@
 import React from 'react';
-import { KEY_DOWN, KEY_UP } from '../../../keys';
-import {
-  Label,
-  TextContainer,
-  TextField,
-  TextInputContainer,
-  TextMirror,
-  ValueContainer
-} from './shared';
+import { NumberInput } from '../../inputs/NumberInput';
+import { Label, ValueContainer } from './shared';
 
 type Props = {
   id: string;
@@ -17,59 +10,13 @@ type Props = {
 };
 
 export function NumberItem({ id, label, value, onChange }: Props) {
-  const [focused, setFocused] = React.useState(false);
-  const onFocus = React.useCallback(() => setFocused(true), []);
-  const onBlur = React.useCallback(() => setFocused(false), []);
-
-  const onInputChange = React.useCallback(
-    (e: React.SyntheticEvent<HTMLTextAreaElement>) => {
-      const newValue = +e.currentTarget.value;
-      if (isFinite(newValue)) {
-        onChange(newValue);
-      }
-    },
-    [onChange]
-  );
-
-  const onKeyDown = React.useCallback(
-    (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
-      switch (e.keyCode) {
-        case KEY_UP:
-          e.preventDefault();
-          return onChange(value + 1);
-        case KEY_DOWN:
-          e.preventDefault();
-          return onChange(value - 1);
-        default:
-        // Nada
-      }
-    },
-    [value, onChange]
-  );
-
   return (
     <>
       <Label title={label} htmlFor={id}>
         {label}
       </Label>
       <ValueContainer>
-        <TextInputContainer focused={focused}>
-          <TextContainer>
-            <TextMirror style={{ opacity: focused ? 0 : 1 }}>
-              {value}
-            </TextMirror>
-            <TextField
-              rows={1}
-              id={id}
-              value={value}
-              onChange={onInputChange}
-              onFocus={onFocus}
-              onBlur={onBlur}
-              onKeyDown={onKeyDown}
-              style={{ opacity: focused ? 1 : 0 }}
-            />
-          </TextContainer>
-        </TextInputContainer>
+        <NumberInput id={id} value={value} onChange={onChange} />
       </ValueContainer>
     </>
   );

--- a/packages/react-cosmos-playground2/src/shared/ui/valueInputTree/ValueInputTreeItem/NumberItem.tsx
+++ b/packages/react-cosmos-playground2/src/shared/ui/valueInputTree/ValueInputTreeItem/NumberItem.tsx
@@ -1,33 +1,52 @@
 import React from 'react';
+import { KEY_DOWN, KEY_UP } from '../../../keys';
 import {
   Label,
-  ValueContainer,
-  TextInputContainer,
   TextContainer,
   TextField,
-  TextMirror
+  TextInputContainer,
+  TextMirror,
+  ValueContainer
 } from './shared';
 
 type Props = {
   id: string;
   label: string;
-  value: string;
-  onChange: (newValue: string) => unknown;
+  value: number;
+  onChange: (newValue: number) => unknown;
 };
 
-export function StringInput({ id, label, value, onChange }: Props) {
+export function NumberItem({ id, label, value, onChange }: Props) {
   const [focused, setFocused] = React.useState(false);
   const onFocus = React.useCallback(() => setFocused(true), []);
   const onBlur = React.useCallback(() => setFocused(false), []);
 
   const onInputChange = React.useCallback(
-    (e: React.SyntheticEvent<HTMLTextAreaElement>) =>
-      onChange(e.currentTarget.value),
+    (e: React.SyntheticEvent<HTMLTextAreaElement>) => {
+      const newValue = +e.currentTarget.value;
+      if (isFinite(newValue)) {
+        onChange(newValue);
+      }
+    },
     [onChange]
   );
 
-  // Mirror textarea behavior and add an extra row after user adds a new line
-  const mirrorText = focused ? value.replace(/\n$/, `\n `) : value;
+  const onKeyDown = React.useCallback(
+    (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
+      switch (e.keyCode) {
+        case KEY_UP:
+          e.preventDefault();
+          return onChange(value + 1);
+        case KEY_DOWN:
+          e.preventDefault();
+          return onChange(value - 1);
+        default:
+        // Nada
+      }
+    },
+    [value, onChange]
+  );
+
   return (
     <>
       <Label title={label} htmlFor={id}>
@@ -37,7 +56,7 @@ export function StringInput({ id, label, value, onChange }: Props) {
         <TextInputContainer focused={focused}>
           <TextContainer>
             <TextMirror style={{ opacity: focused ? 0 : 1 }}>
-              {mirrorText}
+              {value}
             </TextMirror>
             <TextField
               rows={1}
@@ -46,6 +65,7 @@ export function StringInput({ id, label, value, onChange }: Props) {
               onChange={onInputChange}
               onFocus={onFocus}
               onBlur={onBlur}
+              onKeyDown={onKeyDown}
               style={{ opacity: focused ? 1 : 0 }}
             />
           </TextContainer>

--- a/packages/react-cosmos-playground2/src/shared/ui/valueInputTree/ValueInputTreeItem/StringItem.tsx
+++ b/packages/react-cosmos-playground2/src/shared/ui/valueInputTree/ValueInputTreeItem/StringItem.tsx
@@ -1,12 +1,11 @@
 import React from 'react';
 import {
-  Label,
-  ValueContainer,
-  TextInputContainer,
   TextContainer,
   TextField,
+  TextInputContainer,
   TextMirror
-} from './shared';
+} from '../../inputs/shared';
+import { ValueContainer, Label } from './shared';
 
 type Props = {
   id: string;

--- a/packages/react-cosmos-playground2/src/shared/ui/valueInputTree/ValueInputTreeItem/StringItem.tsx
+++ b/packages/react-cosmos-playground2/src/shared/ui/valueInputTree/ValueInputTreeItem/StringItem.tsx
@@ -33,7 +33,11 @@ export function StringItem({ id, label, value, onChange }: Props) {
         {label}
       </Label>
       <ValueContainer>
-        <TextInputContainer focused={focused}>
+        <TextInputContainer
+          focused={focused}
+          focusedBg="var(--grey1)"
+          focusedBoxShadow="0 0 0.5px 1px var(--primary4)"
+        >
           <TextContainer>
             <TextMirror minWidth={24} focused={focused}>
               {mirrorText}
@@ -42,10 +46,11 @@ export function StringItem({ id, label, value, onChange }: Props) {
               rows={1}
               id={id}
               value={value}
+              focused={focused}
+              color="var(--grey7)"
               onChange={onInputChange}
               onFocus={onFocus}
               onBlur={onBlur}
-              style={{ opacity: focused ? 1 : 0 }}
             />
           </TextContainer>
         </TextInputContainer>

--- a/packages/react-cosmos-playground2/src/shared/ui/valueInputTree/ValueInputTreeItem/StringItem.tsx
+++ b/packages/react-cosmos-playground2/src/shared/ui/valueInputTree/ValueInputTreeItem/StringItem.tsx
@@ -1,52 +1,33 @@
 import React from 'react';
-import { KEY_DOWN, KEY_UP } from '../../../../shared/keys';
 import {
   Label,
+  ValueContainer,
+  TextInputContainer,
   TextContainer,
   TextField,
-  TextInputContainer,
-  TextMirror,
-  ValueContainer
+  TextMirror
 } from './shared';
 
 type Props = {
   id: string;
   label: string;
-  value: number;
-  onChange: (newValue: number) => unknown;
+  value: string;
+  onChange: (newValue: string) => unknown;
 };
 
-export function NumberInput({ id, label, value, onChange }: Props) {
+export function StringItem({ id, label, value, onChange }: Props) {
   const [focused, setFocused] = React.useState(false);
   const onFocus = React.useCallback(() => setFocused(true), []);
   const onBlur = React.useCallback(() => setFocused(false), []);
 
   const onInputChange = React.useCallback(
-    (e: React.SyntheticEvent<HTMLTextAreaElement>) => {
-      const newValue = +e.currentTarget.value;
-      if (isFinite(newValue)) {
-        onChange(newValue);
-      }
-    },
+    (e: React.SyntheticEvent<HTMLTextAreaElement>) =>
+      onChange(e.currentTarget.value),
     [onChange]
   );
 
-  const onKeyDown = React.useCallback(
-    (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
-      switch (e.keyCode) {
-        case KEY_UP:
-          e.preventDefault();
-          return onChange(value + 1);
-        case KEY_DOWN:
-          e.preventDefault();
-          return onChange(value - 1);
-        default:
-        // Nada
-      }
-    },
-    [value, onChange]
-  );
-
+  // Mirror textarea behavior and add an extra row after user adds a new line
+  const mirrorText = focused ? value.replace(/\n$/, `\n `) : value;
   return (
     <>
       <Label title={label} htmlFor={id}>
@@ -56,7 +37,7 @@ export function NumberInput({ id, label, value, onChange }: Props) {
         <TextInputContainer focused={focused}>
           <TextContainer>
             <TextMirror style={{ opacity: focused ? 0 : 1 }}>
-              {value}
+              {mirrorText}
             </TextMirror>
             <TextField
               rows={1}
@@ -65,7 +46,6 @@ export function NumberInput({ id, label, value, onChange }: Props) {
               onChange={onInputChange}
               onFocus={onFocus}
               onBlur={onBlur}
-              onKeyDown={onKeyDown}
               style={{ opacity: focused ? 1 : 0 }}
             />
           </TextContainer>

--- a/packages/react-cosmos-playground2/src/shared/ui/valueInputTree/ValueInputTreeItem/StringItem.tsx
+++ b/packages/react-cosmos-playground2/src/shared/ui/valueInputTree/ValueInputTreeItem/StringItem.tsx
@@ -35,7 +35,7 @@ export function StringItem({ id, label, value, onChange }: Props) {
       <ValueContainer>
         <TextInputContainer focused={focused}>
           <TextContainer>
-            <TextMirror style={{ opacity: focused ? 0 : 1 }}>
+            <TextMirror minWidth={24} focused={focused}>
               {mirrorText}
             </TextMirror>
             <TextField

--- a/packages/react-cosmos-playground2/src/shared/ui/valueInputTree/ValueInputTreeItem/StringItem.tsx
+++ b/packages/react-cosmos-playground2/src/shared/ui/valueInputTree/ValueInputTreeItem/StringItem.tsx
@@ -3,7 +3,8 @@ import {
   TextContainer,
   TextField,
   TextInputContainer,
-  TextMirror
+  TextMirror,
+  useFocus
 } from '../../inputs/shared';
 import { ValueContainer, Label } from './shared';
 
@@ -15,9 +16,7 @@ type Props = {
 };
 
 export function StringItem({ id, label, value, onChange }: Props) {
-  const [focused, setFocused] = React.useState(false);
-  const onFocus = React.useCallback(() => setFocused(true), []);
-  const onBlur = React.useCallback(() => setFocused(false), []);
+  const { focused, onFocus, onBlur } = useFocus();
 
   const onInputChange = React.useCallback(
     (e: React.ChangeEvent<HTMLTextAreaElement>) =>

--- a/packages/react-cosmos-playground2/src/shared/ui/valueInputTree/ValueInputTreeItem/StringItem.tsx
+++ b/packages/react-cosmos-playground2/src/shared/ui/valueInputTree/ValueInputTreeItem/StringItem.tsx
@@ -20,7 +20,7 @@ export function StringItem({ id, label, value, onChange }: Props) {
   const onBlur = React.useCallback(() => setFocused(false), []);
 
   const onInputChange = React.useCallback(
-    (e: React.SyntheticEvent<HTMLTextAreaElement>) =>
+    (e: React.ChangeEvent<HTMLTextAreaElement>) =>
       onChange(e.currentTarget.value),
     [onChange]
   );

--- a/packages/react-cosmos-playground2/src/shared/ui/valueInputTree/ValueInputTreeItem/UnserializableItem.tsx
+++ b/packages/react-cosmos-playground2/src/shared/ui/valueInputTree/ValueInputTreeItem/UnserializableItem.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Label, ValueContainer, UneditableInput } from './shared';
+import { ValueContainer, Label, UneditableInput } from './shared';
 
 type Props = {
   id: string;

--- a/packages/react-cosmos-playground2/src/shared/ui/valueInputTree/ValueInputTreeItem/UnserializableItem.tsx
+++ b/packages/react-cosmos-playground2/src/shared/ui/valueInputTree/ValueInputTreeItem/UnserializableItem.tsx
@@ -7,7 +7,7 @@ type Props = {
   value: string;
 };
 
-export function UnserializableInput({ id, label, value }: Props) {
+export function UnserializableItem({ id, label, value }: Props) {
   return (
     <>
       <Label title={label} htmlFor={id}>

--- a/packages/react-cosmos-playground2/src/shared/ui/valueInputTree/ValueInputTreeItem/index.tsx
+++ b/packages/react-cosmos-playground2/src/shared/ui/valueInputTree/ValueInputTreeItem/index.tsx
@@ -7,11 +7,11 @@ import {
   FixtureStateValues
 } from 'react-cosmos-shared2/fixtureState';
 import { TreeItemValue, TreeItemContainer } from '../shared';
-import { UnserializableInput } from './UnserializableInput';
-import { StringInput } from './StringInput';
-import { NumberInput } from './NumberInput';
-import { BooleanInput } from './BooleanInput';
-import { NullInput } from './NullInput';
+import { UnserializableItem } from './UnserializableItem';
+import { StringItem } from './StringItem';
+import { NumberItem } from './NumberItem';
+import { BooleanItem } from './BooleanItem';
+import { NullItem } from './NullItem';
 
 type Props = {
   treeId: string;
@@ -43,14 +43,14 @@ export function ValueInputTreeItem({
 
   return (
     <TreeItemContainer indentLevel={parents.length}>
-      <InputContainer>
-        {getInput(item, itemId, itemName, onInputChange)}
-      </InputContainer>
+      <ItemContainer>
+        {getItem(item, itemId, itemName, onInputChange)}
+      </ItemContainer>
     </TreeItemContainer>
   );
 }
 
-export const InputContainer = styled.div`
+export const ItemContainer = styled.div`
   display: flex;
   flex-direction: row;
   align-items: flex-start;
@@ -59,7 +59,7 @@ export const InputContainer = styled.div`
   padding: 0;
 `;
 
-function getInput(
+function getItem(
   item: TreeItemValue,
   id: string,
   label: string,
@@ -67,17 +67,13 @@ function getInput(
 ) {
   if (item.type === 'unserializable') {
     return (
-      <UnserializableInput
-        id={id}
-        label={label}
-        value={item.stringifiedValue}
-      />
+      <UnserializableItem id={id} label={label} value={item.stringifiedValue} />
     );
   }
 
   if (typeof item.value === 'string') {
     return (
-      <StringInput
+      <StringItem
         id={id}
         label={label}
         value={item.value}
@@ -88,7 +84,7 @@ function getInput(
 
   if (typeof item.value === 'number') {
     return (
-      <NumberInput
+      <NumberItem
         id={id}
         label={label}
         value={item.value}
@@ -99,7 +95,7 @@ function getInput(
 
   if (typeof item.value === 'boolean') {
     return (
-      <BooleanInput
+      <BooleanItem
         id={id}
         label={label}
         value={item.value}
@@ -109,7 +105,7 @@ function getInput(
   }
 
   if (item.value === null) {
-    return <NullInput id={id} label={label} />;
+    return <NullItem id={id} label={label} />;
   }
 
   throw new Error(`Invalid primitive value: ${item.value}`);

--- a/packages/react-cosmos-playground2/src/shared/ui/valueInputTree/ValueInputTreeItem/shared.tsx
+++ b/packages/react-cosmos-playground2/src/shared/ui/valueInputTree/ValueInputTreeItem/shared.tsx
@@ -21,46 +21,6 @@ export const ValueContainer = styled.div`
   overflow: hidden;
 `;
 
-export const TextInputContainer = styled.div<{ focused: boolean }>`
-  box-sizing: border-box;
-  max-width: 100%;
-  padding: 2px 4px;
-  border-radius: 3px;
-  background: ${props => (props.focused ? 'var(--grey1)' : 'transparent')};
-  box-shadow: ${props =>
-    props.focused ? '0 0 0.5px 1px var(--primary4)' : 'none'};
-`;
-
-export const TextContainer = styled.div`
-  position: relative;
-`;
-
-export const TextField = styled.textarea`
-  position: absolute;
-  z-index: 1;
-  top: 0;
-  left: 0;
-  width: 100%;
-  height: 100%;
-  border: 0;
-  background: none;
-  color: var(--grey7);
-  line-height: 20px;
-  white-space: pre;
-  overflow: hidden;
-  outline: none;
-  resize: none;
-`;
-
-export const TextMirror = styled.div`
-  min-width: 32px;
-  min-height: 20px;
-  line-height: 20px;
-  white-space: pre;
-  overflow: hidden;
-  text-overflow: ellipsis;
-`;
-
 export const UneditableInput = styled.span`
   box-sizing: border-box;
   height: 24px;


### PR DESCRIPTION
- [x] Make device list a dropdown, which scales to many more possible options
  - [x] Convert buttons to native select
  - [x] Style native select button
- [x] Make viewport width and height manually adjustable (incl. up/down keys)
  - [x] Add number inputs
  - [x] Style number inputs for light-colored context
  - [x] Improve number/string inputs
- [x] Persist viewport state (`enabled`, `viewport` and `scaled`)