### PR TITLE
Surface errors from user modules

### DIFF
--- a/packages/react-cosmos/src/shared/fs.ts
+++ b/packages/react-cosmos/src/shared/fs.ts
@@ -2,11 +2,9 @@
 import fs from 'fs';
 
 export function requireModule(modulePath: string) {
-  try {
-    return require(modulePath);
-  } catch (err) {
-    return undefined;
-  }
+  // This purpose of this wrapper is merely to make it easy to mock user
+  // modules in tests
+  return require(modulePath);
 }
 
 // Better than fs.exists because it works for module paths without an extension


### PR DESCRIPTION
This includes:
- Cosmos config (previously the config would be ignored and a default config would be used instead 😱)
- Webpack config (previously a cryptic error was shown)
- Webpack override config (previously a cryptic error was shown)