### PR TITLE
Use backslashes for watchDirs on Windows so HMR works

### DIFF
--- a/packages/react-cosmos/src/config/__tests__/watchDirs.ts
+++ b/packages/react-cosmos/src/config/__tests__/watchDirs.ts
@@ -1,9 +1,9 @@
-import { getCwdPath } from '../../testHelpers/cwd';
+import path from 'path';
 import { createCosmosConfig } from '..';
 
 it('returns resolved default watchDirs', () => {
   const cosmosConfig = createCosmosConfig(process.cwd());
-  expect(cosmosConfig.watchDirs).toEqual([getCwdPath('.')]);
+  expect(cosmosConfig.watchDirs).toEqual([process.cwd()]);
 });
 
 it('returns resolved custom watchDirs', () => {
@@ -11,7 +11,7 @@ it('returns resolved custom watchDirs', () => {
     watchDirs: ['src1', 'src2']
   });
   expect(cosmosConfig.watchDirs).toEqual([
-    getCwdPath('src1'),
-    getCwdPath('src2')
+    path.resolve(process.cwd(), 'src1'),
+    path.resolve(process.cwd(), 'src2')
   ]);
 });

--- a/packages/react-cosmos/src/config/createCosmosConfig.ts
+++ b/packages/react-cosmos/src/config/createCosmosConfig.ts
@@ -50,6 +50,11 @@ function getFixtureFileSuffix({
 
 function getWatchDirs(cosmosConfigInput: CosmosConfigInput, rootDir: string) {
   const { watchDirs = ['.'] } = cosmosConfigInput;
+  // Watchpack v1.6.0 (and by extensions webpack v4) has problems watching
+  // directories with forward slashes on Windows. Use backslashes until it gets
+  // fixed.
+  // See https://github.com/webpack/watchpack/issues/123 and
+  // https://github.com/react-cosmos/react-cosmos/issues/1069
   return watchDirs.map(watchDir => path.resolve(rootDir, watchDir));
 }
 

--- a/packages/react-cosmos/src/config/createCosmosConfig.ts
+++ b/packages/react-cosmos/src/config/createCosmosConfig.ts
@@ -1,3 +1,4 @@
+import path from 'path';
 import { getCliArgs } from '../shared/cli';
 import { resolveModule, resolvePath } from './resolve';
 import { CosmosConfig, CosmosConfigInput } from './shared';
@@ -49,7 +50,7 @@ function getFixtureFileSuffix({
 
 function getWatchDirs(cosmosConfigInput: CosmosConfigInput, rootDir: string) {
   const { watchDirs = ['.'] } = cosmosConfigInput;
-  return watchDirs.map(watchDir => resolvePath(rootDir, watchDir));
+  return watchDirs.map(watchDir => path.resolve(rootDir, watchDir));
 }
 
 function getUserDepsFilePath(


### PR DESCRIPTION
Fixes #1069 by using path.resolve for watchDirs instead of the custom resolvePath, which changes all slashes to forward slashes. Watchpack (and by extension webpack) has trouble watching a directory with forward slashes on Windows.