### PR TITLE
Fix building and linting on Windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "scripts": {
     "prettify": "prettier --write \"{{packages/*/src,examples,cypress,scripts}/**/,}*.{js,jsx,ts,tsx,css,md}\"",
     "check-types": "tsc",
-    "lint": "eslint '**/*.{ts,tsx}'",
+    "lint": "eslint \"**/*.{ts,tsx}\"",
     "test:unit": "jest --config .jest/config.js",
     "test:watch": "yarn test:unit --watch",
     "test:coverage": "yarn test:unit --coverage",

--- a/packages/react-cosmos-playground2/webpack.config.js
+++ b/packages/react-cosmos-playground2/webpack.config.js
@@ -36,7 +36,7 @@ module.exports = {
     rules: [
       {
         test: /\.tsx?$/,
-        include: [/packages\/react-cosmos-playground2\/src/],
+        include: src,
         use: {
           loader: 'babel-loader'
         }

--- a/scripts/build.ts
+++ b/scripts/build.ts
@@ -216,7 +216,8 @@ function runAsyncTask({ cmd, args, env = {} }: RunAsyncTaskArgs) {
       env: {
         ...process.env,
         ...env
-      }
+      },
+      shell: true
     });
     cp.stdout.on('data', data => {
       stdout.write(data);


### PR DESCRIPTION
Builds and lints on Windows. Note that several unit tests still fail because of inconsistent path handling. For example, `mockFs.ts` stores file paths with forward slashes but `detectCosmosConfigPath()` uses `path.resolve`. However, the number of code changes to eliminate all test failures seems too invasive for this PR. 

Personally, I think converting to forward slashes **everywhere** on Windows is more trouble than it's worth. From what I can tell, the only place they are useful is when generating the `userDeps` file/string because backslashes would have to be escaped again to generate the correct Javascript. Everywhere else, the ultimate consumer of paths is some Node API that can handle either separator just fine.