### PR TITLE
Advanced httpProxy options

### DIFF
--- a/packages/react-cosmos/config.schema.json
+++ b/packages/react-cosmos/config.schema.json
@@ -55,43 +55,40 @@
       "description": "Dev server port. [default: 5000]",
       "type": "number"
     },
-	"httpProxy": {
-	  "description": "Proxy some URLs to a different HTTP server (eg. an API backend dev server). Similar to devServer.proxy in webpack config.",
-	  "type": "object",
-	  "additionalProperties": true,
-	  "patternProperties": {
-		".*": {
-		  "type": "string"
-		},
-		"/.*": {
-		  "type": "object",
-		  "description": "advanced http proxy config",
-		  "additionalProperties": true,
-		  "required": [
-		    "target"
-		  ],
-		  "properties": {
-			"target": {
-			  "type": "string"
-			},
-			"secure": {
-			  "type": "boolean"
-			},
-			"pathRewrite": {
-			  "type": "object",
-			  "patternProperties": {
-				".*": {
-			      "type": "string"
-			    }
-		      }
-		    },
-		    "logLevel": {
-		      "type": "string"
-		    }
-	  	  }
-	    }
-	  }
-	},
+    "httpProxy": {
+      "description": "Proxy some URLs to a different HTTP server (eg. an API backend dev server). Similar to devServer.proxy in webpack config.",
+      "type": "object",
+      "additionalProperties": true,
+      "patternProperties": {
+        ".*": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "object",
+              "description": "Advanced HTTP proxy config",
+              "additionalProperties": true,
+              "required": ["target"],
+              "properties": {
+                "target": { "type": "string" },
+                "secure": { "type": "boolean" },
+                "pathRewrite": {
+                  "type": "object",
+                  "patternProperties": {
+                    ".*": { "type": "string" }
+                  }
+                },
+                "logLevel": {
+                  "type": "string",
+                  "enum": ["error", "debug", "info", "warn", "silent"]
+                }
+              }
+            }
+          ]
+        }
+      }
+    },
     "globalImports": {
       "description": "Modules to be imported before loading components. Stuff like reset.css, polyfills, etc.",
       "type": "array",

--- a/packages/react-cosmos/config.schema.json
+++ b/packages/react-cosmos/config.schema.json
@@ -55,14 +55,43 @@
       "description": "Dev server port. [default: 5000]",
       "type": "number"
     },
-    "httpProxy": {
-      "description": "Proxy some URLs to a different HTTP server (eg. an API backend dev server). Similar to devServer.proxy in webpack config.",
-      "type": "object",
-      "additionalProperties": true,
-      "patternProperties": {
-        ".*": { "type": "string" }
-      }
-    },
+	"httpProxy": {
+	  "description": "Proxy some URLs to a different HTTP server (eg. an API backend dev server). Similar to devServer.proxy in webpack config.",
+	  "type": "object",
+	  "additionalProperties": true,
+	  "patternProperties": {
+		".*": {
+		  "type": "string"
+		},
+		"/.*": {
+		  "type": "object",
+		  "description": "advanced http proxy config",
+		  "additionalProperties": true,
+		  "required": [
+		    "target"
+		  ],
+		  "properties": {
+			"target": {
+			  "type": "string"
+			},
+			"secure": {
+			  "type": "boolean"
+			},
+			"pathRewrite": {
+			  "type": "object",
+			  "patternProperties": {
+				".*": {
+			      "type": "string"
+			    }
+		      }
+		    },
+		    "logLevel": {
+		      "type": "string"
+		    }
+	  	  }
+	    }
+	  }
+	},
     "globalImports": {
       "description": "Modules to be imported before loading components. Stuff like reset.css, polyfills, etc.",
       "type": "array",

--- a/packages/react-cosmos/src/plugins/httpProxy.ts
+++ b/packages/react-cosmos/src/plugins/httpProxy.ts
@@ -2,12 +2,6 @@ import { CosmosConfig } from '../config/shared';
 import httpProxyMiddleware from 'http-proxy-middleware';
 import { DevServerPluginArgs } from '../shared/devServer';
 
-// TODO: Support advanced configuration
-// See https://github.com/react-cosmos/react-cosmos/pull/875 for context
-// Supporting all httpProxy options isn't as easy anymore, because the Cosmos
-// config is now JSON. We can either support a serializable subset of useful
-// options (like "pathRewrite") or optionally support an external config module.
-
 type HttpProxyConfig = {
   [context: string]:
     | string
@@ -15,20 +9,20 @@ type HttpProxyConfig = {
         target: string;
         secure?: boolean;
         pathRewrite?: { [rewrite: string]: string };
-        logLevel?: string;
+        logLevel?: 'error' | 'debug' | 'info' | 'warn' | 'silent';
       };
 };
 
 export function httpProxy({ cosmosConfig, expressApp }: DevServerPluginArgs) {
   const httpProxyConfig = getHttpProxyCosmosConfig(cosmosConfig);
   Object.keys(httpProxyConfig).forEach(context => {
+    let proxy = {};
     if (typeof httpProxyConfig[context] === 'string') {
-      const target = httpProxyConfig[context] as string;
-      expressApp.use(context, httpProxyMiddleware(context, { target: target }));
+      proxy = { target: httpProxyConfig[context] };
     } else if (typeof httpProxyConfig[context] === 'object') {
-      const proxy = httpProxyConfig[context] as object;
-      expressApp.use(context, httpProxyMiddleware(proxy));
+      proxy = httpProxyConfig[context];
     }
+    expressApp.use(context, httpProxyMiddleware(proxy));
   });
 }
 

--- a/packages/react-cosmos/src/plugins/httpProxy.ts
+++ b/packages/react-cosmos/src/plugins/httpProxy.ts
@@ -16,13 +16,12 @@ type HttpProxyConfig = {
 export function httpProxy({ cosmosConfig, expressApp }: DevServerPluginArgs) {
   const httpProxyConfig = getHttpProxyCosmosConfig(cosmosConfig);
   Object.keys(httpProxyConfig).forEach(context => {
-    let proxy = {};
-    if (typeof httpProxyConfig[context] === 'string') {
-      proxy = { target: httpProxyConfig[context] };
-    } else if (typeof httpProxyConfig[context] === 'object') {
-      proxy = httpProxyConfig[context];
+    const config = httpProxyConfig[context];
+    if (typeof config === 'string') {
+      expressApp.use(context, httpProxyMiddleware(context, { target: config }));
+    } else if (typeof config === 'object') {
+      expressApp.use(context, httpProxyMiddleware(context, config));
     }
-    expressApp.use(context, httpProxyMiddleware(proxy));
   });
 }
 

--- a/packages/react-cosmos/src/plugins/httpProxy.ts
+++ b/packages/react-cosmos/src/plugins/httpProxy.ts
@@ -7,13 +7,28 @@ import { DevServerPluginArgs } from '../shared/devServer';
 // Supporting all httpProxy options isn't as easy anymore, because the Cosmos
 // config is now JSON. We can either support a serializable subset of useful
 // options (like "pathRewrite") or optionally support an external config module.
-type HttpProxyConfig = { [context: string]: string };
+
+type HttpProxyConfig = {
+  [context: string]:
+    | string
+    | {
+        target: string;
+        secure?: boolean;
+        pathRewrite?: { [rewrite: string]: string };
+        logLevel?: string;
+      };
+};
 
 export function httpProxy({ cosmosConfig, expressApp }: DevServerPluginArgs) {
   const httpProxyConfig = getHttpProxyCosmosConfig(cosmosConfig);
   Object.keys(httpProxyConfig).forEach(context => {
-    const target = httpProxyConfig[context];
-    expressApp.use(context, httpProxyMiddleware(context, { target }));
+    if (typeof httpProxyConfig[context] === 'string') {
+      const target = httpProxyConfig[context] as string;
+      expressApp.use(context, httpProxyMiddleware(context, { target: target }));
+    } else if (typeof httpProxyConfig[context] === 'object') {
+      const proxy = httpProxyConfig[context] as object;
+      expressApp.use(context, httpProxyMiddleware(proxy));
+    }
   });
 }
 


### PR DESCRIPTION
Advanced httpProxy options include: target, secure, pathRewrite, and logLevel.
Advanced options are optional, httpProxy will accept either a string value to the target, or an object containing the advanced configuration.

Information on exactly how these options are used within http-proxy-middleware are found [here](https://github.com/chimurai/http-proxy-middleware#http-proxy-options).

Example cosmos.config.json:
```
{
  "globalImports": ["polyfills.ts", "globalStyle.css"],
  "staticPath": "static",
  "httpProxy": {
    "/api": {
      "target":"http://localhost:5001",
      "secure": false,
      "pathRewrite":{
        "^/api":""
      },
      "logLevel": "debug"
    },
    "/test": "http://localhost:5002"
  }
}
```

@skidding please review the changes to httpProxy/config.schema.json that we discussed briefly via Slack

