### PR TITLE
add support for async webpack config

### DIFF
--- a/packages/react-cosmos/src/plugins/webpack/devServer.ts
+++ b/packages/react-cosmos/src/plugins/webpack/devServer.ts
@@ -36,10 +36,10 @@ export async function webpackDevServer({
     return;
   }
 
-  const webpackConfig = getDevWebpackConfig(
+  const webpackConfig = (await getDevWebpackConfig(
     cosmosConfig,
     userWebpack
-  ) as WebpackConfig;
+  )) as WebpackConfig;
 
   // Serve static path derived from devServer.contentBase webpack config
   if (cosmosConfig.staticPath === null) {

--- a/packages/react-cosmos/src/plugins/webpack/export.ts
+++ b/packages/react-cosmos/src/plugins/webpack/export.ts
@@ -9,7 +9,7 @@ export async function webpackExport({ cosmosConfig }: ExportPluginArgs) {
     return;
   }
 
-  const webpackConfig = getExportWebpackConfig(cosmosConfig, userWebpack);
+  const webpackConfig = await getExportWebpackConfig(cosmosConfig, userWebpack);
   try {
     await runWebpackCompiler(userWebpack, webpackConfig);
   } catch (err) {

--- a/packages/react-cosmos/src/plugins/webpack/webpackConfig/__tests__/customDevConfig.ts
+++ b/packages/react-cosmos/src/plugins/webpack/webpackConfig/__tests__/customDevConfig.ts
@@ -42,7 +42,7 @@ async function getCustomDevWebpackConfig() {
         overridePath: 'mywebpack.override.js'
       }
     });
-    return getDevWebpackConfig(cosmosConfig, webpack);
+    return await getDevWebpackConfig(cosmosConfig, webpack);
   });
 }
 

--- a/packages/react-cosmos/src/plugins/webpack/webpackConfig/__tests__/customExportConfig.ts
+++ b/packages/react-cosmos/src/plugins/webpack/webpackConfig/__tests__/customExportConfig.ts
@@ -31,7 +31,7 @@ async function getCustomExportWebpackConfig() {
         configPath: 'mywebpack.config.js'
       }
     });
-    return getExportWebpackConfig(cosmosConfig, webpack);
+    return await getExportWebpackConfig(cosmosConfig, webpack);
   });
 }
 

--- a/packages/react-cosmos/src/plugins/webpack/webpackConfig/__tests__/defaultDevConfig.ts
+++ b/packages/react-cosmos/src/plugins/webpack/webpackConfig/__tests__/defaultDevConfig.ts
@@ -15,7 +15,7 @@ async function getDefaultDevWebpackConfig() {
   return mockConsole(async ({ expectLog }) => {
     expectLog('[Cosmos] Using default webpack config');
     const cosmosConfig = createCosmosConfig(process.cwd());
-    return getDevWebpackConfig(cosmosConfig, webpack);
+    return await getDevWebpackConfig(cosmosConfig, webpack);
   });
 }
 

--- a/packages/react-cosmos/src/plugins/webpack/webpackConfig/__tests__/defaultExportConfig.ts
+++ b/packages/react-cosmos/src/plugins/webpack/webpackConfig/__tests__/defaultExportConfig.ts
@@ -16,7 +16,7 @@ async function getDefaultExportWebpackConfig() {
   return mockConsole(async ({ expectLog }) => {
     expectLog('[Cosmos] Using default webpack config');
     const cosmosConfig = createCosmosConfig(process.cwd());
-    return getExportWebpackConfig(cosmosConfig, webpack);
+    return await getExportWebpackConfig(cosmosConfig, webpack);
   });
 }
 

--- a/packages/react-cosmos/src/plugins/webpack/webpackConfig/devServer.ts
+++ b/packages/react-cosmos/src/plugins/webpack/webpackConfig/devServer.ts
@@ -12,11 +12,14 @@ import {
   resolveLocalReactDeps
 } from './shared';
 
-export function getDevWebpackConfig(
+export async function getDevWebpackConfig(
   cosmosConfig: CosmosConfig,
   userWebpack: typeof webpack
-): webpack.Configuration {
-  const baseWebpackConfig = getUserWebpackConfig(cosmosConfig, userWebpack);
+): Promise<webpack.Configuration> {
+  const baseWebpackConfig = await getUserWebpackConfig(
+    cosmosConfig,
+    userWebpack
+  );
   return {
     ...baseWebpackConfig,
     entry: getEntry(cosmosConfig),

--- a/packages/react-cosmos/src/plugins/webpack/webpackConfig/export.ts
+++ b/packages/react-cosmos/src/plugins/webpack/webpackConfig/export.ts
@@ -10,11 +10,14 @@ import {
   resolveLocalReactDeps
 } from './shared';
 
-export function getExportWebpackConfig(
+export async function getExportWebpackConfig(
   cosmosConfig: CosmosConfig,
   userWebpack: typeof webpack
-): webpack.Configuration {
-  const baseWebpackConfig = getUserWebpackConfig(cosmosConfig, userWebpack);
+): Promise<webpack.Configuration> {
+  const baseWebpackConfig = await getUserWebpackConfig(
+    cosmosConfig,
+    userWebpack
+  );
   return {
     ...baseWebpackConfig,
     entry: getEntry(),

--- a/packages/react-cosmos/src/plugins/webpack/webpackConfig/shared.ts
+++ b/packages/react-cosmos/src/plugins/webpack/webpackConfig/shared.ts
@@ -21,11 +21,14 @@ type WebpackOverride = (
   env: string
 ) => webpack.Configuration;
 
-export function getUserWebpackConfig(
+export async function getUserWebpackConfig(
   cosmosConfig: CosmosConfig,
   userWebpack: typeof webpack
 ) {
-  const baseWebpackConfig = getBaseWebpackConfig(cosmosConfig, userWebpack);
+  const baseWebpackConfig = await getBaseWebpackConfig(
+    cosmosConfig,
+    userWebpack
+  );
   const { overridePath } = createWebpackCosmosConfig(cosmosConfig);
 
   if (!overridePath || !moduleExists(overridePath)) {
@@ -41,7 +44,7 @@ export function getUserWebpackConfig(
   return webpackOverride(baseWebpackConfig, getNodeEnv());
 }
 
-export function getBaseWebpackConfig(
+export async function getBaseWebpackConfig(
   cosmosConfig: CosmosConfig,
   userWebpack: typeof webpack
 ) {
@@ -60,7 +63,7 @@ export function getBaseWebpackConfig(
     requireModule(configPath)
   ) as WebpackConfigExport;
   return typeof userConfigExport === 'function'
-    ? userConfigExport(argv.env || getNodeEnv(), argv)
+    ? await userConfigExport(argv.env || getNodeEnv(), argv)
     : userConfigExport;
 }
 


### PR DESCRIPTION
Resolves #1114

According to [Webpack docs](https://webpack.js.org/configuration/configuration-types/#exporting-a-promise), webpack config can be exported as a Promise.
It seems like there are no extra tests needed for this changes.