### PR TITLE
Fix infinite reload when static export strips .html extension

### DIFF
--- a/packages/react-cosmos-playground2/src/plugins/RendererPreview/__tests__/iframe.tsx
+++ b/packages/react-cosmos-playground2/src/plugins/RendererPreview/__tests__/iframe.tsx
@@ -125,4 +125,14 @@ if (nodeVersion >= 10) {
 
     expect(pushStickyNotification).not.toBeCalled();
   });
+
+  it('does not show notification when renderer iframe .html extension is stripped', async () => {
+    registerTestPlugins();
+    const { pushStickyNotification } = mockNotifications();
+    const renderer = loadTestPlugins();
+
+    await mockRendererLocation(renderer, `/_renderer`);
+
+    expect(pushStickyNotification).not.toBeCalled();
+  });
 }

--- a/packages/react-cosmos-playground2/src/plugins/RendererPreview/handleRendererRequests.ts
+++ b/packages/react-cosmos-playground2/src/plugins/RendererPreview/handleRendererRequests.ts
@@ -76,6 +76,8 @@ function iframeLocationChanged(iframeWindow: Window, iframeSrc: string) {
     const locationWithoutHash = href.split('#')[0];
     return (
       locationWithoutHash !== iframeSrc &&
+      // Some static servers strip .html extensions automatically
+      // https://github.com/zeit/serve-handler/tree/ce35fcd4e1c67356348f4735eed88fb084af9b43#cleanurls-booleanarray
       locationWithoutHash !== iframeSrc.replace(/\.html$/, '')
     );
   } catch (err) {

--- a/packages/react-cosmos-playground2/src/plugins/RendererPreview/handleRendererRequests.ts
+++ b/packages/react-cosmos-playground2/src/plugins/RendererPreview/handleRendererRequests.ts
@@ -74,8 +74,10 @@ function iframeLocationChanged(iframeWindow: Window, iframeSrc: string) {
   try {
     const { href } = iframeWindow.location;
     const locationWithoutHash = href.split('#')[0];
-    const locationCompareStart = locationWithoutHash.length - iframeSrc.length;
-    return locationWithoutHash.substring(locationCompareStart) !== iframeSrc;
+    return (
+      locationWithoutHash !== iframeSrc &&
+      locationWithoutHash !== iframeSrc.replace(/\.html$/, '')
+    );
   } catch (err) {
     // An exception is thrown when trying to access the location of a
     // cross-origin frame, which signals that the iframe location host changed.


### PR DESCRIPTION
Prevent infinite reload when static export is served with .html extension stripping