### PR TITLE
Correct direction in FixtureName

### DIFF
--- a/packages/react-cosmos-playground2/src/plugins/Root/RendererHeader.tsx
+++ b/packages/react-cosmos-playground2/src/plugins/Root/RendererHeader.tsx
@@ -168,5 +168,4 @@ const FixtureName = styled.div`
   white-space: nowrap;
   text-overflow: ellipsis;
   overflow: hidden;
-  direction: rtl;
 `;


### PR DESCRIPTION
With original `direction: rtl`:

<img width="563" alt="image" src="https://user-images.githubusercontent.com/3297808/80297165-2017ec80-87c4-11ea-8b09-e001e9231c97.png">

Notice how it's not visible when the fixture name doesn't contain a `>`:
<img width="563" alt="image" src="https://user-images.githubusercontent.com/3297808/80297163-17bfb180-87c4-11ea-8d17-3d4397719bee.png">

With patch:

<img width="563" alt="image" src="https://user-images.githubusercontent.com/3297808/80297198-5eada700-87c4-11ea-8616-1361a3506f51.png">


