### PR TITLE
Fix auto fixture file detection in Create React App

### DIFF
--- a/packages/react-cosmos/src/plugins/webpack/webpackConfig/devServer.ts
+++ b/packages/react-cosmos/src/plugins/webpack/webpackConfig/devServer.ts
@@ -34,13 +34,15 @@ export async function getDevWebpackConfig(
   };
 
   // optimization.splitChunks.name = false breaks auto fixture file discovery.
-  // Existing fixtures hot reload just fine, but added/removed fixture files
-  // wouldn't (dis)appear in the Cosmos UI without a page refresh. The webpack
-  // build would update, but our module.hot.accept callback didn't get called:
+  // When the splitChunks.name is set to false, existing fixtures hot reload
+  // fine, but added or removed fixture files don't appear or disappear in the
+  // React Cosmos UI automatically — a page refresh is required. The webpack
+  // build updates correctly, but module.hot.accept isn't called on the client:
   // https://github.com/react-cosmos/react-cosmos/blob/548e9b7e9ca9fbc66f3915861cf1ae9d60222b28/packages/react-cosmos/src/plugins/webpack/client/index.ts#L24-L29
-  // I don't know _why_ this setting has this effect, but I discovered this bug
-  // in Create React App, which uses this setting:
+  // Create React App uses this setting:
   // https://github.com/facebook/create-react-app/blob/37712374bcaa6ccb168eeaf4fe8bd52d120dbc58/packages/react-scripts/config/webpack.config.js#L286
+  // Apparently it's a webpack 4 bug:
+  // https://twitter.com/wSokra/status/1255925851557974016
   if (webpackConfig.optimization?.splitChunks) {
     const { name } = webpackConfig.optimization.splitChunks;
     if (name === false) delete webpackConfig.optimization.splitChunks.name;

--- a/packages/react-cosmos/src/plugins/webpack/webpackConfig/devServer.ts
+++ b/packages/react-cosmos/src/plugins/webpack/webpackConfig/devServer.ts
@@ -33,12 +33,13 @@ export async function getDevWebpackConfig(
     plugins: getPlugins(cosmosConfig, baseWebpackConfig, userWebpack),
   };
 
-  // optimization.splitChunks.name = false partially breaks fixture hot reload.
-  // Existing fixtures are hot reloaded fine, but added/removed fixture files
-  // don't (dis)appear in the Cosmos UI without a page refresh. The build gets
-  // updated, but our module.hot.accept callback doesn't get called. I don't
-  // know _why_ this setting has this effect, but I discovered this bug in
-  // Create React App, which uses this setting:
+  // optimization.splitChunks.name = false partially breaks auto fixture file
+  // discovery. Existing fixtures hot reload, but added/removed fixture files
+  // wouldn't (dis)appear in the Cosmos UI without a page refresh. The webpack
+  // build would update, but our module.hot.accept callback didn't get called:
+  // https://github.com/react-cosmos/react-cosmos/blob/548e9b7e9ca9fbc66f3915861cf1ae9d60222b28/packages/react-cosmos/src/plugins/webpack/client/index.ts#L24-L29
+  // I don't know _why_ this setting has this effect, but I discovered this bug
+  // in Create React App, which uses this setting:
   // https://github.com/facebook/create-react-app/blob/37712374bcaa6ccb168eeaf4fe8bd52d120dbc58/packages/react-scripts/config/webpack.config.js#L286
   if (webpackConfig.optimization?.splitChunks) {
     const { name } = webpackConfig.optimization.splitChunks;

--- a/packages/react-cosmos/src/plugins/webpack/webpackConfig/devServer.ts
+++ b/packages/react-cosmos/src/plugins/webpack/webpackConfig/devServer.ts
@@ -33,8 +33,8 @@ export async function getDevWebpackConfig(
     plugins: getPlugins(cosmosConfig, baseWebpackConfig, userWebpack),
   };
 
-  // optimization.splitChunks.name = false partially breaks auto fixture file
-  // discovery. Existing fixtures hot reload, but added/removed fixture files
+  // optimization.splitChunks.name = false breaks auto fixture file discovery.
+  // Existing fixtures hot reload just fine, but added/removed fixture files
   // wouldn't (dis)appear in the Cosmos UI without a page refresh. The webpack
   // build would update, but our module.hot.accept callback didn't get called:
   // https://github.com/react-cosmos/react-cosmos/blob/548e9b7e9ca9fbc66f3915861cf1ae9d60222b28/packages/react-cosmos/src/plugins/webpack/client/index.ts#L24-L29


### PR DESCRIPTION
`optimization.splitChunks.name = false` breaks auto fixture file discovery. Existing fixtures hot reload just fine, but added/removed fixture files wouldn't (dis)appear in the Cosmos UI without a page refresh. The webpack build would update, but our `module.hot.accept` callback didn't get called: https://github.com/react-cosmos/react-cosmos/blob/548e9b7e9ca9fbc66f3915861cf1ae9d60222b28/packages/react-cosmos/src/plugins/webpack/client/index.ts#L24-L29

I don't know _why_ this setting has this effect, but I discovered this bug while running React Cosmos inside Create React App, which uses this setting: https://github.com/facebook/create-react-app/blob/37712374bcaa6ccb168eeaf4fe8bd52d120dbc58/packages/react-scripts/config/webpack.config.js#L286.