### PR TITLE
Options to enable HTTPS server mode for cosmos-server

### DIFF
--- a/packages/react-cosmos/config.schema.json
+++ b/packages/react-cosmos/config.schema.json
@@ -64,11 +64,11 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "cert": {
+        "certPath": {
           "description": "Path of a certificate file",
           "type": "string"
         },
-        "key": {
+        "keyPath": {
           "description": "Path of a certificate's key file",
           "type": "string"
         }

--- a/packages/react-cosmos/config.schema.json
+++ b/packages/react-cosmos/config.schema.json
@@ -55,6 +55,25 @@
       "description": "Dev server port. [default: 5000]",
       "type": "number"
     },
+    "https": {
+      "description": "Server will be served over HTTPS",
+      "type": "boolean"
+    },
+    "httpsOptions": {
+      "description": "Additional options for HTTPS server",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "cert": {
+          "description": "Path of a certificate file",
+          "type": "string"
+        },
+        "key": {
+          "description": "Path of a certificate's key file",
+          "type": "string"
+        }
+      }
+    },
     "httpProxy": {
       "description": "Proxy some URLs to a different HTTP server (eg. an API backend dev server). Similar to devServer.proxy in webpack config.",
       "type": "object",

--- a/packages/react-cosmos/package.json
+++ b/packages/react-cosmos/package.json
@@ -18,6 +18,7 @@
     "lodash": "^4.17.15",
     "micromatch": "^4.0.2",
     "open": "^7.0.3",
+    "pem": "^1.14.4",
     "pkg-up": "^3.1.0",
     "react-cosmos-playground2": "^5.4.0",
     "react-cosmos-shared2": "^5.4.0",

--- a/packages/react-cosmos/src/config/createCosmosConfig.ts
+++ b/packages/react-cosmos/src/config/createCosmosConfig.ts
@@ -12,8 +12,7 @@ export function createCosmosConfig(
     rootDir,
     exportPath: getExportPath(cosmosConfigInput, rootDir),
     staticPath: getStaticPath(cosmosConfigInput, rootDir),
-    httpsKeyPath: getHttpsKeyPath(cosmosConfigInput, rootDir),
-    httpsCertPath: getHttpsCertPath(cosmosConfigInput, rootDir),
+    httpsOptions: getHttpsOptions(cosmosConfigInput, rootDir),
     publicUrl: getPublicUrl(cosmosConfigInput),
     fixturesDir: getFixturesDir(cosmosConfigInput),
     fixtureFileSuffix: getFixtureFileSuffix(cosmosConfigInput),
@@ -36,20 +35,20 @@ function getStaticPath(cosmosConfigInput: CosmosConfigInput, rootDir: string) {
   return staticPath && path.resolve(rootDir, staticPath);
 }
 
-function getHttpsKeyPath(
+function getHttpsOptions(
   cosmosConfigInput: CosmosConfigInput,
   rootDir: string
 ) {
-  const httpsKeyPath = cosmosConfigInput?.httpsOptions?.keyPath;
-  return httpsKeyPath && path.resolve(rootDir, httpsKeyPath);
-}
-
-function getHttpsCertPath(
-  cosmosConfigInput: CosmosConfigInput,
-  rootDir: string
-) {
-  const httpsCertPath = cosmosConfigInput.httpsOptions?.certPath;
-  return httpsCertPath && path.resolve(rootDir, httpsCertPath);
+  if (
+    cosmosConfigInput.httpsOptions?.keyPath &&
+    cosmosConfigInput.httpsOptions?.certPath
+  ) {
+    return {
+      keyPath: path.resolve(rootDir, cosmosConfigInput.httpsOptions.keyPath),
+      certPath: path.resolve(rootDir, cosmosConfigInput.httpsOptions.certPath),
+    };
+  }
+  return null;
 }
 
 function getPublicUrl({ publicUrl = '/' }: CosmosConfigInput) {

--- a/packages/react-cosmos/src/config/createCosmosConfig.ts
+++ b/packages/react-cosmos/src/config/createCosmosConfig.ts
@@ -12,6 +12,8 @@ export function createCosmosConfig(
     rootDir,
     exportPath: getExportPath(cosmosConfigInput, rootDir),
     staticPath: getStaticPath(cosmosConfigInput, rootDir),
+    httpsKeyPath: getHttpsKeyPath(cosmosConfigInput, rootDir),
+    httpsCertPath: getHttpsCertPath(cosmosConfigInput, rootDir),
     publicUrl: getPublicUrl(cosmosConfigInput),
     fixturesDir: getFixturesDir(cosmosConfigInput),
     fixtureFileSuffix: getFixtureFileSuffix(cosmosConfigInput),
@@ -32,6 +34,22 @@ function getExportPath(cosmosConfigInput: CosmosConfigInput, rootDir: string) {
 function getStaticPath(cosmosConfigInput: CosmosConfigInput, rootDir: string) {
   const { staticPath = null } = cosmosConfigInput;
   return staticPath && path.resolve(rootDir, staticPath);
+}
+
+function getHttpsKeyPath(
+  cosmosConfigInput: CosmosConfigInput,
+  rootDir: string
+) {
+  const httpsKeyPath = cosmosConfigInput?.httpsOptions?.keyPath;
+  return httpsKeyPath && path.resolve(rootDir, httpsKeyPath);
+}
+
+function getHttpsCertPath(
+  cosmosConfigInput: CosmosConfigInput,
+  rootDir: string
+) {
+  const httpsCertPath = cosmosConfigInput.httpsOptions?.certPath;
+  return httpsCertPath && path.resolve(rootDir, httpsCertPath);
 }
 
 function getPublicUrl({ publicUrl = '/' }: CosmosConfigInput) {

--- a/packages/react-cosmos/src/config/shared.ts
+++ b/packages/react-cosmos/src/config/shared.ts
@@ -12,6 +12,12 @@ export type CosmosConfig = {
   // unspecified IPv4 address (0.0.0.0) otherwise.
   hostname: null | string;
   port: number;
+  https?: boolean;
+  httpsOptions?: {
+    key: string;
+    cert: string;
+    ca: string;
+  };
   rootDir: string;
   staticPath: null | string;
   publicUrl: string;

--- a/packages/react-cosmos/src/config/shared.ts
+++ b/packages/react-cosmos/src/config/shared.ts
@@ -14,10 +14,11 @@ export type CosmosConfig = {
   port: number;
   https?: boolean;
   httpsOptions?: {
-    key: string;
-    cert: string;
-    ca: string;
+    keyPath?: string;
+    certPath?: string;
   };
+  httpsKeyPath?: string;
+  httpsCertPath?: string;
   rootDir: string;
   staticPath: null | string;
   publicUrl: string;

--- a/packages/react-cosmos/src/config/shared.ts
+++ b/packages/react-cosmos/src/config/shared.ts
@@ -1,5 +1,10 @@
 import { requireModule } from '../shared/fs';
 
+interface HttpsOptions {
+  keyPath: string;
+  certPath: string;
+}
+
 export type CosmosConfig = {
   exportPath: string;
   fixtureFileSuffix: string;
@@ -12,13 +17,7 @@ export type CosmosConfig = {
   // unspecified IPv4 address (0.0.0.0) otherwise.
   hostname: null | string;
   port: number;
-  https?: boolean;
-  httpsOptions?: {
-    keyPath?: string;
-    certPath?: string;
-  };
-  httpsKeyPath?: string;
-  httpsCertPath?: string;
+  httpsOptions: null | HttpsOptions;
   rootDir: string;
   staticPath: null | string;
   publicUrl: string;

--- a/packages/react-cosmos/src/getFixtures2.ts
+++ b/packages/react-cosmos/src/getFixtures2.ts
@@ -92,8 +92,8 @@ function getRendererUrl(cosmosConfig: CosmosConfig, fixtureId: FixtureId) {
   return `${host}${urlPath}?${query}`;
 }
 
-function getPlaygroundHost({ hostname, port }: CosmosConfig) {
-  return `http://${hostname || 'localhost'}:${port}`;
+function getPlaygroundHost({ hostname, port, https }: CosmosConfig) {
+  return `${https ? 'https' : 'http'}://${hostname || 'localhost'}:${port}`;
 }
 
 function createFixtureElementGetter(

--- a/packages/react-cosmos/src/shared/devServer/httpServer.ts
+++ b/packages/react-cosmos/src/shared/devServer/httpServer.ts
@@ -13,13 +13,7 @@ export async function createHttpServer(
   cosmosConfig: CosmosConfig,
   requestListener: RequestListener
 ) {
-  const {
-    port,
-    hostname,
-    https: httpsEnabled,
-    httpsKeyPath,
-    httpsCertPath,
-  } = cosmosConfig;
+  const { port, hostname, https: httpsEnabled, httpsOptions } = cosmosConfig;
 
   let server: Server;
   if (httpsEnabled) {
@@ -28,10 +22,10 @@ export async function createHttpServer(
       cert: string;
     };
 
-    if (httpsKeyPath && httpsCertPath) {
+    if (httpsOptions) {
       credentials = {
-        key: fs.readFileSync(httpsKeyPath, 'utf8'),
-        cert: fs.readFileSync(httpsCertPath, 'utf8'),
+        key: fs.readFileSync(httpsOptions.keyPath, 'utf8'),
+        cert: fs.readFileSync(httpsOptions.certPath, 'utf8'),
       };
     } else {
       credentials = await new Promise((resolve, reject) => {

--- a/packages/react-cosmos/src/shared/devServer/httpServer.ts
+++ b/packages/react-cosmos/src/shared/devServer/httpServer.ts
@@ -1,4 +1,7 @@
-import http from 'http';
+import http, { Server } from 'http';
+import https from 'https';
+import fs from 'fs';
+const pem = require('pem');
 import { CosmosConfig } from '../../config';
 
 type RequestListener = (
@@ -6,12 +9,54 @@ type RequestListener = (
   response: http.ServerResponse
 ) => void;
 
-export function createHttpServer(
+export async function createHttpServer(
   cosmosConfig: CosmosConfig,
   requestListener: RequestListener
 ) {
-  const { port, hostname } = cosmosConfig;
-  const server = http.createServer(requestListener);
+  const { port, hostname, https: httpsEnabled, httpsOptions } = cosmosConfig;
+
+  let server: Server;
+  if (httpsEnabled) {
+    let credentials: {
+      key: string;
+      cert: string;
+    };
+
+    if (httpsOptions?.key && httpsOptions?.cert) {
+      credentials = {
+        key: fs.readFileSync(httpsOptions.key, 'utf8'),
+        cert: fs.readFileSync(httpsOptions.cert, 'utf8'),
+      };
+    } else {
+      credentials = await new Promise((resolve, reject) => {
+        pem.createCertificate(
+          {
+            days: 1000,
+            selfSigned: true,
+          },
+          (
+            err: Error,
+            keys: {
+              serviceKey: string;
+              certificate: string;
+            }
+          ) => {
+            if (err) {
+              return reject(err);
+            }
+            return resolve({
+              key: keys.serviceKey,
+              cert: keys.certificate,
+            });
+          }
+        );
+      });
+    }
+
+    server = https.createServer(credentials, requestListener);
+  } else {
+    server = http.createServer(requestListener);
+  }
 
   async function start() {
     await new Promise(resolve => {
@@ -23,7 +68,8 @@ export function createHttpServer(
     });
 
     const hostnameDisplay = hostname || 'localhost';
-    console.log(`[Cosmos] See you at http://${hostnameDisplay}:${port}`);
+    const protocol = httpsEnabled ? 'https' : 'http';
+    console.log(`[Cosmos] See you at ${protocol}://${hostnameDisplay}:${port}`);
   }
 
   async function stop() {

--- a/packages/react-cosmos/src/shared/devServer/httpServer.ts
+++ b/packages/react-cosmos/src/shared/devServer/httpServer.ts
@@ -13,7 +13,13 @@ export async function createHttpServer(
   cosmosConfig: CosmosConfig,
   requestListener: RequestListener
 ) {
-  const { port, hostname, https: httpsEnabled, httpsOptions } = cosmosConfig;
+  const {
+    port,
+    hostname,
+    https: httpsEnabled,
+    httpsKeyPath,
+    httpsCertPath,
+  } = cosmosConfig;
 
   let server: Server;
   if (httpsEnabled) {
@@ -22,10 +28,10 @@ export async function createHttpServer(
       cert: string;
     };
 
-    if (httpsOptions?.key && httpsOptions?.cert) {
+    if (httpsKeyPath && httpsCertPath) {
       credentials = {
-        key: fs.readFileSync(httpsOptions.key, 'utf8'),
-        cert: fs.readFileSync(httpsOptions.cert, 'utf8'),
+        key: fs.readFileSync(httpsKeyPath, 'utf8'),
+        cert: fs.readFileSync(httpsCertPath, 'utf8'),
       };
     } else {
       credentials = await new Promise((resolve, reject) => {

--- a/packages/react-cosmos/src/shared/devServer/index.ts
+++ b/packages/react-cosmos/src/shared/devServer/index.ts
@@ -34,7 +34,7 @@ export async function startDevServer(
   }
 
   const pluginCleanupCallbacks: PluginCleanupCallback[] = [];
-  const httpServer = createHttpServer(cosmosConfig, app);
+  const httpServer = await createHttpServer(cosmosConfig, app);
   await httpServer.start();
 
   const msgHandler = createMessageHandler(httpServer.server);

--- a/yarn.lock
+++ b/yarn.lock
@@ -4025,6 +4025,11 @@ chardet@^0.7.0:
   resolved "https://registry.yarnpkg.com/chardet/-/chardet-0.7.0.tgz#90094849f0937f2eedc2425d0d28a9e5f0cbad9e"
   integrity sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==
 
+charenc@~0.0.1:
+  version "0.0.2"
+  resolved "https://registry.yarnpkg.com/charenc/-/charenc-0.0.2.tgz#c0a1d2f3a7092e03774bfa83f14c0fc5790a8667"
+  integrity sha1-wKHS86cJLgN3S/qD8UwPxXkKhmc=
+
 check-more-types@2.24.0:
   version "2.24.0"
   resolved "https://registry.yarnpkg.com/check-more-types/-/check-more-types-2.24.0.tgz#1420ffb10fd444dcfc79b43891bbfffd32a84600"
@@ -4640,6 +4645,11 @@ cross-spawn@^7.0.0:
     path-key "^3.1.0"
     shebang-command "^2.0.0"
     which "^2.0.1"
+
+crypt@~0.0.1:
+  version "0.0.2"
+  resolved "https://registry.yarnpkg.com/crypt/-/crypt-0.0.2.tgz#88d7ff7ec0dfb86f713dc87bbb42d044d3e6c41b"
+  integrity sha1-iNf/fsDfuG9xPch7u0LQRNPmxBs=
 
 crypto-browserify@^3.11.0:
   version "3.12.0"
@@ -5374,6 +5384,11 @@ es6-promisify@^5.0.0:
   integrity sha1-UQnWLz5W6pZ8S2NQWu8IKRyKUgM=
   dependencies:
     es6-promise "^4.0.3"
+
+es6-promisify@^6.0.0:
+  version "6.1.1"
+  resolved "https://registry.yarnpkg.com/es6-promisify/-/es6-promisify-6.1.1.tgz#46837651b7b06bf6fff893d03f29393668d01621"
+  integrity sha512-HBL8I3mIki5C1Cc9QjKUenHtnG0A5/xA8Q/AllRcfiwl2CZFXGK7ddBiCoRwAix4i2KxcQfjtIVcrVbB3vbmwg==
 
 escape-html@~1.0.3:
   version "1.0.3"
@@ -6930,7 +6945,7 @@ is-binary-path@~2.1.0:
   dependencies:
     binary-extensions "^2.0.0"
 
-is-buffer@^1.1.5:
+is-buffer@^1.1.5, is-buffer@~1.1.1:
   version "1.1.6"
   resolved "https://registry.yarnpkg.com/is-buffer/-/is-buffer-1.1.6.tgz#efaa2ea9daa0d7ab2ea13a97b2b8ad51fefbe8be"
   integrity sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==
@@ -8249,6 +8264,15 @@ md5.js@^1.3.4:
     inherits "^2.0.1"
     safe-buffer "^5.1.2"
 
+md5@^2.2.1:
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/md5/-/md5-2.2.1.tgz#53ab38d5fe3c8891ba465329ea23fac0540126f9"
+  integrity sha1-U6s41f48iJG6RlMp6iP6wFQBJvk=
+  dependencies:
+    charenc "~0.0.1"
+    crypt "~0.0.1"
+    is-buffer "~1.1.1"
+
 media-typer@0.3.0:
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/media-typer/-/media-typer-0.3.0.tgz#8710d7af0aa626f8fffa1ce00168545263255748"
@@ -9070,7 +9094,7 @@ os-name@^3.1.0:
     macos-release "^2.2.0"
     windows-release "^3.1.0"
 
-os-tmpdir@^1.0.0, os-tmpdir@~1.0.2:
+os-tmpdir@^1.0.0, os-tmpdir@^1.0.1, os-tmpdir@~1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/os-tmpdir/-/os-tmpdir-1.0.2.tgz#bbe67406c79aa85c5cfec766fe5734555dfa1274"
   integrity sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=
@@ -9438,6 +9462,16 @@ pbkdf2@^3.0.3:
     ripemd160 "^2.0.1"
     safe-buffer "^5.0.1"
     sha.js "^2.4.8"
+
+pem@^1.14.4:
+  version "1.14.4"
+  resolved "https://registry.yarnpkg.com/pem/-/pem-1.14.4.tgz#a68c70c6e751ccc5b3b5bcd7af78b0aec1177ff9"
+  integrity sha512-v8lH3NpirgiEmbOqhx0vwQTxwi0ExsiWBGYh0jYNq7K6mQuO4gI6UEFlr6fLAdv9TPXRt6GqiwE37puQdIDS8g==
+  dependencies:
+    es6-promisify "^6.0.0"
+    md5 "^2.2.1"
+    os-tmpdir "^1.0.1"
+    which "^2.0.2"
 
 pend@~1.2.0:
   version "1.2.0"


### PR DESCRIPTION
Fixes #1218

It can work with custom cert+key files or generate them automatically if there are no any provided.

Valid configs:
```
{
  "https": true
}
```
or
```
{
  "https": true,
  "httpsOptions": {
    "key": "cert/server.key",
    "cert": "cert/server.crt"
  }
}
