### PR TITLE
Fix playground error when Webpack config uses `react-refresh-webpack-plugin`

### DIFF
--- a/packages/react-cosmos-playground2/package.json
+++ b/packages/react-cosmos-playground2/package.json
@@ -16,6 +16,7 @@
     "react-dom": "17.0.1",
     "react-is": "^17.0.1",
     "react-plugin": "^2.0.0-alpha.8",
+    "react-refresh": "^0.9.0",
     "socket.io-client": "2.3.1",
     "styled-components": "^5.2.0"
   }

--- a/packages/react-cosmos-playground2/package.json
+++ b/packages/react-cosmos-playground2/package.json
@@ -16,7 +16,6 @@
     "react-dom": "17.0.1",
     "react-is": "^17.0.1",
     "react-plugin": "^2.0.0-alpha.8",
-    "react-refresh": "^0.9.0",
     "socket.io-client": "2.3.1",
     "styled-components": "^5.2.0"
   }

--- a/packages/react-cosmos/package.json
+++ b/packages/react-cosmos/package.json
@@ -24,6 +24,7 @@
     "react-cosmos-plugin": "^5.5.0",
     "react-cosmos-shared2": "^5.5.1",
     "react-error-overlay": "^6.0.8",
+    "react-refresh": "^0.9.0",
     "regenerator-runtime": "^0.13.7",
     "resolve-from": "^5.0.0",
     "slash": "^3.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -10565,6 +10565,11 @@ react-plugin@^2.0.0-alpha.8:
     lodash "^4.17.11"
     ui-plugin "^2.0.0-alpha.4"
 
+react-refresh@^0.9.0:
+  version "0.9.0"
+  resolved "https://registry.yarnpkg.com/react-refresh/-/react-refresh-0.9.0.tgz#71863337adc3e5c2f8a6bfddd12ae3bfe32aafbf"
+  integrity sha512-Gvzk7OZpiqKSkxsQvO/mbTN1poglhmAV7gR/DdIrRrSMXraRQQlfikRJOr3Nb9GTMPC5kof948Zy6jJZIFtDvQ==
+
 react-shallow-renderer@^16.13.1:
   version "16.14.1"
   resolved "https://registry.yarnpkg.com/react-shallow-renderer/-/react-shallow-renderer-16.14.1.tgz#bf0d02df8a519a558fd9b8215442efa5c840e124"


### PR DESCRIPTION
Fix for #1272 

After adding the `react-refresh` package to `react-cosmos-playground2`'s dev dependencies I am no longer receiving "Error: Already listening" when running my project using `react-scripts@4.0.0`'s Webpack config. It appears that `react-refresh` is a dependency of `@pmmmwh/react-refresh-webpack-plugin` and without it the new hot module reloading doesn't function properly.

I tried directly installing `react-refresh` as a dependency to my Cosmos project, but the playground still gives me the same error referenced in #1272. 

I understand this causes the project to take on an extra dependency just for users with a specific configuration, but I'm unsure of how else to solve the issue. If you have any suggestions or this sparks a different idea for how to solve it I'd be happy to re-implement it that way as well!