### PR TITLE
Make the output.path undefined

### DIFF
--- a/packages/react-cosmos/src/plugins/webpack/webpackConfig/__tests__/customDevConfig.ts
+++ b/packages/react-cosmos/src/plugins/webpack/webpackConfig/__tests__/customDevConfig.ts
@@ -97,7 +97,6 @@ it('create output', async () => {
   expect(output).toEqual(
     expect.objectContaining({
       filename: '[name].js',
-      path: '/',
       publicPath: '/',
     })
   );

--- a/packages/react-cosmos/src/plugins/webpack/webpackConfig/__tests__/defaultDevConfig.ts
+++ b/packages/react-cosmos/src/plugins/webpack/webpackConfig/__tests__/defaultDevConfig.ts
@@ -43,7 +43,6 @@ it('create output', async () => {
   expect(output).toEqual(
     expect.objectContaining({
       filename: '[name].js',
-      path: '/',
       publicPath: '/',
     })
   );

--- a/packages/react-cosmos/src/plugins/webpack/webpackConfig/devServer.ts
+++ b/packages/react-cosmos/src/plugins/webpack/webpackConfig/devServer.ts
@@ -66,9 +66,6 @@ function getEntry(cosmosConfig: CosmosConfig) {
 function getOutput({ publicUrl }: CosmosConfig) {
   const filename = '[name].js';
   return {
-    // Setting path to `/` in development (where files are saved in memory and
-    // not on disk) is a weird required for old webpack versions
-    path: '/',
     filename,
     publicPath: publicUrl,
     // Enable click-to-open source in react-error-overlay


### PR DESCRIPTION
Setting the output path to '/' causes plugins like clean-webpack-plugin to
scan the entire filesystem, reporting errors when they encounter files
they cannot read.

Other tools like create-react-app set simply set the output path to undefined:

https://github.com/facebook/create-react-app/blob/c1714042b60ff48cb08407bec236c0a92d26773b/packages/react-scripts/config/webpack.config.js#L157-L158

Fixes #1279