### PR TITLE
fix userDepsTemplate slash for windows

### DIFF
--- a/packages/react-cosmos/src/shared/userDeps/userDepsTemplate.ts
+++ b/packages/react-cosmos/src/shared/userDeps/userDepsTemplate.ts
@@ -70,6 +70,6 @@ function createImportMap(
 
 function resolveImportPath(filePath: string, relativeToDir: string | null) {
   return relativeToDir
-    ? `.${path.sep}${path.relative(relativeToDir, filePath)}`
+    ? slash(`.${path.sep}${path.relative(relativeToDir, filePath)}`)
     : filePath;
 }


### PR DESCRIPTION
Example output of a `cosmos.userdeps.js` file before the fix on Windows.

```
import fixture0 from '.\components\Button.fixture.jsx';

export const rendererConfig = {
  "port": 5000
};

export const fixtures = {
  'src/components/Button.fixture.jsx': fixture0
};

export const decorators = {

};
```

Example after fix

```
import fixture0 from './components/Button.fixture.jsx';

export const rendererConfig = {
  "port": 5000
};

export const fixtures = {
  'src/components/Button.fixture.jsx': fixture0
};

export const decorators = {

};
```

Note the `import fixture0 from '.\components\Button.fixture.jsx';` line has relative pathing that is invalid with Windows. This either needs to be escaped or changed to forward slashes. As the slash package is already here and being used in this file, best to just use that to change to forward slashes in the Windows environment.

No negative impact on OSX/Linux dev environments.