### PR TITLE
 Fix userDepsTemplate slash on Windows for absolute file paths

### DIFF
--- a/packages/react-cosmos/src/shared/userDeps/userDepsTemplate.ts
+++ b/packages/react-cosmos/src/shared/userDeps/userDepsTemplate.ts
@@ -69,7 +69,9 @@ function createImportMap(
 }
 
 function resolveImportPath(filePath: string, relativeToDir: string | null) {
-  return relativeToDir
-    ? slash(`.${path.sep}${path.relative(relativeToDir, filePath)}`)
-    : filePath;
+  return slash(
+    relativeToDir
+      ? `.${path.sep}${path.relative(relativeToDir, filePath)}`
+      : filePath
+  );
 }


### PR DESCRIPTION
Possible fix for #1332

Based on the fix for #1321 here: https://github.com/react-cosmos/react-cosmos/commit/bfd3b41ca46a7747971885fa68c2731a5bda0257

I tried to test and build but I get resolve errors in react-cosmos-playground2 (with and without the patch) which I don't have time to look into right now