### PR TITLE
Restore optional peer dependencies (+ snowpack docs update)

### DIFF
--- a/docs/snowpack.md
+++ b/docs/snowpack.md
@@ -35,7 +35,7 @@ Create `index.cosmos.tsx` next to your existing index module.
 
 ```jsx
 import { mountDomRenderer } from 'react-cosmos/dom';
-import { decorators, fixtures, rendererConfig } from './cosmos.userdeps';
+import { decorators, fixtures, rendererConfig } from './cosmos.userdeps.js';
 
 mountDomRenderer({ rendererConfig, decorators, fixtures });
 
@@ -67,6 +67,16 @@ routes: [
   { src: '/_renderer.html', dest: '/index.cosmos.html' },
   // Other routes...
 ],
+```
+
+Enable the `polyfillNode` flag in the `packageOptions` of your Snowpack config.
+
+```js
+// snowpack.config.js
+packageOptions: {
+  polyfillNode: true,
+  // Other package options...
+},
 ```
 
 ### 4. Start React Cosmos with Snowpack

--- a/packages/react-cosmos-shared2/package.json
+++ b/packages/react-cosmos-shared2/package.json
@@ -10,5 +10,13 @@
     "react-element-to-jsx-string": "^14.3.2",
     "react-is": "^17.0.2",
     "socket.io-client": "2.2.0"
+  },
+  "peerDependencies": {
+    "react": ">= 16.8"
+  },
+  "peerDependenciesMeta": {
+    "react": {
+      "optional": true
+    }
   }
 }

--- a/packages/react-cosmos/package.json
+++ b/packages/react-cosmos/package.json
@@ -33,6 +33,22 @@
     "webpack-dev-middleware": "^4.3.0",
     "yargs": "^16.2.0"
   },
+  "peerDependencies": {
+    "react": ">= 16.8",
+    "react-dom": ">= 16.8",
+    "webpack": ">= 4.0"
+  },
+  "peerDependenciesMeta": {
+    "react": {
+      "optional": true
+    },
+    "react-dom": {
+      "optional": true
+    },
+    "webpack": {
+      "optional": true
+    }
+  },
   "bin": {
     "cosmos": "./bin/cosmos.js",
     "cosmos-export": "./bin/cosmos-export.js",


### PR DESCRIPTION
## Issue

Based on [this issue conversation](https://github.com/react-cosmos/react-cosmos/issues/1266#issuecomment-698842147), peer dependencies used to exist in this project, but were removed in order to avoid warning messages that appeared for users installing it in projects where `react` (or `webpack`) wasn't a direct dependency, such as CRA.

This is causing compatibility issues with `snowpack`'s [esinstall](https://github.com/snowpackjs/snowpack/tree/main/esinstall) tool, which uses rollup to transform all modules in the project into esmodules. I haven't dug too deep into the _exact_ reason, but when it encounters an undeclared dependency it seems to automatically bundle a copy of it into the module that requested it.

The lack of peer dependencies also causes `yarn` to throw warnings when installing the package.

## Resolution

This PR restores the correct peer dependencies back to the `react-cosmos` and `react-cosmos-shared2` packages. They're marked as optional inside `peerDependenciesMeta` in order to avoid the warning scenario described earlier.

I also updated the instructions for installing cosmos in a snowpack project, to bring it up to date with the latest versions of snowpack.

This resolves #1320 and #1266.

## Notes / Open Questions

I chose `react/react-dom >= 16.8` and `webpack >= 4` in order to loosely match the [requirements from the docs](https://github.com/react-cosmos/react-cosmos/tree/main/docs#requirements), but maybe it would be better to set a cap, at least on the webpack version, to avoid issues arising from them releasing a new major version?

## Todo

The [snowpack demo project](https://github.com/react-cosmos/react-cosmos-snowpack) should probably be updated based on the changes to the install instructions too.
