### PR TITLE
allow copy to clipboard from playground

### DIFF
--- a/packages/react-cosmos-playground2/src/plugins/RendererPreview/RendererPreview.tsx
+++ b/packages/react-cosmos-playground2/src/plugins/RendererPreview/RendererPreview.tsx
@@ -25,6 +25,7 @@ export const RendererPreview = React.memo(function RendererPreview({
           ref={onIframeRef}
           src={rendererUrl}
           frameBorder={0}
+          allow="clipboard-write *"
         />
       </Container>
     </Slot>


### PR DESCRIPTION
Clipboard functionality is blocked by CORS when Cosmos and the renderer are on different origins.

This change allows testing of components that copy text to the clipboard.