### PR TITLE
Fix flag for generating userdeps in custom build setup guide

### DIFF
--- a/docs/customBundlerSetup.md
+++ b/docs/customBundlerSetup.md
@@ -23,7 +23,7 @@ Next, choose a port for the renderer other than the main Cosmos port, say `5050`
 }
 ```
 
-Next, start Cosmos with the `--generate-userdeps` CLI flag. This will generate a `cosmos.userdeps.js` module that contains maps of user module imports (fixtures and decorators) as well the renderer config. Feel free to add this file to .gitignore.
+Next, start Cosmos with the `--external-userdeps` CLI flag. This will generate a `cosmos.userdeps.js` module that contains maps of user module imports (fixtures and decorators) as well the renderer config. Feel free to add this file to .gitignore.
 
 Finally, create a web server using your bundler of choice that serves an `index.html`, which loads a JS module with the following code:
 


### PR DESCRIPTION
I tried to use Cosmos with custom bundler setup and run into issue that `--generate-userdeps` flag mentioned in [`customBundlerSetup.md`](https://github.com/react-cosmos/react-cosmos/blob/main/docs/customBundlerSetup.md) does not generate file. Later I find in [Troubleshooting](https://github.com/react-cosmos/react-cosmos/blob/main/docs/customBundlerSetup.md) section of readme, that same behavior mentioned to fix with `--external-userdeps` flag. Tried this one and it works, so I filled this PR to fix flag name in custom bundler setup guide :)

Btw, overall experience in using it with custom bundler goes smooth, I used it with Parcel. Thanks for your awesome work! 🥇 