### PR TITLE
Chore(cosmos-ui): enable fullscreen permission on RendererPreview iframe

### DIFF
--- a/packages/react-cosmos-ui/src/plugins/RendererPreview/RendererPreview.tsx
+++ b/packages/react-cosmos-ui/src/plugins/RendererPreview/RendererPreview.tsx
@@ -37,7 +37,7 @@ export const RendererPreview = React.memo(function RendererPreview({
           ref={onIframeRef}
           src={createRendererUrl(rendererUrl)}
           frameBorder={0}
-          allow="clipboard-write *"
+          allow="clipboard-write *; fullscreen *;"
         />
         <RendererOverlay runtimeStatus={runtimeStatus} />
       </Container>


### PR DESCRIPTION
- see https://github.com/react-cosmos/react-cosmos/issues/1529

[video](https://github.com/react-cosmos/react-cosmos/assets/10324554/8d36d210-6c2a-4548-bcaa-0b5f4f8c974a)




