### PR TITLE
Skip Corepack check in PnP CI job

### DIFF
--- a/.github/workflows/test-pnp.yml
+++ b/.github/workflows/test-pnp.yml
@@ -27,6 +27,8 @@ jobs:
           cache-dependency-path: |
             react-cosmos/yarn.lock
             pnp-example/yarn.lock
+        env:
+          SKIP_YARN_COREPACK_CHECK: true
 
       - name: Build react-cosmos packages
         run: |


### PR DESCRIPTION
Temporary fix until Corepack support is added setup-node action: https://github.com/actions/setup-node/issues/531