### PR TITLE
Fix stale fixture props when HMR causes a remount

### DIFF
--- a/packages/react-cosmos-renderer/src/__tests__/fixtureSelectWithState.tsx
+++ b/packages/react-cosmos-renderer/src/__tests__/fixtureSelectWithState.tsx
@@ -15,9 +15,10 @@ const fixtures = wrapDefaultExport({
 });
 const fixtureId = { path: 'first' };
 
+// Skipped because of https://github.com/react-cosmos/react-cosmos/pull/1614
 testRenderer(
   'renders selected fixture with fixture state',
-  { rendererId, fixtures },
+  { rendererId, fixtures, skip: true },
   async ({ renderer, selectFixture }) => {
     selectFixture({
       rendererId,

--- a/packages/react-cosmos-renderer/src/fixture/FixtureCapture/props/index.ts
+++ b/packages/react-cosmos-renderer/src/fixture/FixtureCapture/props/index.ts
@@ -24,7 +24,7 @@ export function usePropsCapture(
   decoratorId: FixtureDecoratorId
 ) {
   const [propsFs, setPropsFs] = useFixtureState<PropsFixtureState>('props');
-  const prevFixtureRef = useRef(fixture);
+  const prevFixtureRef = useRef<ReactNode>(null);
   const elPaths = findRelevantElementPaths(fixture);
 
   useEffect(() => {

--- a/packages/react-cosmos-renderer/src/fixture/FixtureCapture/props/index.ts
+++ b/packages/react-cosmos-renderer/src/fixture/FixtureCapture/props/index.ts
@@ -69,8 +69,8 @@ export function usePropsCapture(
         // - Override new fixture element props with fixture state props values
         // - Override fixture state props with new fixture element props values
         // We chose the latter because it makes HMR more reliable by allowing
-        // users to update props in Node fixtures source code (when HMR isn't
-        // working optimally, which might be common.)
+        // users to update props in Node fixtures via source code (when HMR
+        // isn't working optimally, which might be common.)
         // The downside is that a renderer that loads a fixture with fixture
         // state will ignore that fixture state initially. This is more of an
         // edge case that probably few people will run into.

--- a/packages/react-cosmos-renderer/src/fixture/FixtureCapture/props/index.ts
+++ b/packages/react-cosmos-renderer/src/fixture/FixtureCapture/props/index.ts
@@ -71,9 +71,10 @@ export function usePropsCapture(
         // We chose the latter because it makes HMR more reliable by allowing
         // users to update props in Node fixtures via source code (when HMR
         // isn't working optimally, which might be common.)
-        // The downside is that a renderer that loads a fixture with fixture
-        // state will ignore that fixture state initially. This is more of an
-        // edge case that probably few people will run into.
+        // The downside with this approach is that a renderer that loads a
+        // fixture with fixture state will ignore props from the fixture state
+        // initially. This is more of an edge case that probably few people will
+        // run into. For more context, see:
         // https://github.com/react-cosmos/react-cosmos/pull/1614
         const prevChildEl = getElementAtPath(prevFixtureRef.current, elPath);
         if (!areNodesEqual(prevChildEl, childEl, false)) {

--- a/packages/react-cosmos-renderer/src/fixture/FixtureCapture/props/index.ts
+++ b/packages/react-cosmos-renderer/src/fixture/FixtureCapture/props/index.ts
@@ -68,9 +68,9 @@ export function usePropsCapture(
         // For this reason we have a tradeoff:
         // - Override new fixture element props with fixture state props values
         // - Override fixture state props with new fixture element props values
-        // We chose the latter because it makes HMR more reliable and allows
-        // users to update props in the source code of Node fixtures when HMR
-        // isn't working optimally, which might be common.
+        // We chose the latter because it makes HMR more reliable by allowing
+        // users to update props in Node fixtures source code (when HMR isn't
+        // working optimally, which might be common.)
         // The downside is that a renderer that loads a fixture with fixture
         // state will ignore that fixture state initially. This is more of an
         // edge case that probably few people will run into.

--- a/packages/react-cosmos-renderer/src/fixture/FixtureCapture/props/index.ts
+++ b/packages/react-cosmos-renderer/src/fixture/FixtureCapture/props/index.ts
@@ -62,6 +62,19 @@ export function usePropsCapture(
           })
         );
       } else {
+        // This code path is problematic because we can't tell whether:
+        // a) This is the first time the fixture renders
+        // b) A (suboptimal) HMR update blew up the FixtureCapture instance
+        // For this reason we have a tradeoff:
+        // - Override new fixture element props with fixture state props values
+        // - Override fixture state props with new fixture element props values
+        // We chose the latter because it makes HMR more reliable and allows
+        // users to update props in the source code of Node fixtures when HMR
+        // isn't working optimally, which might be common.
+        // The downside is that a renderer that loads a fixture with fixture
+        // state will ignore that fixture state initially. This is more of an
+        // edge case that probably few people will run into.
+        // https://github.com/react-cosmos/react-cosmos/pull/1614
         const prevChildEl = getElementAtPath(prevFixtureRef.current, elPath);
         if (!areNodesEqual(prevChildEl, childEl, false)) {
           setPropsFs(prevFs =>

--- a/packages/react-cosmos-renderer/src/testHelpers/mountTestRenderer.tsx
+++ b/packages/react-cosmos-renderer/src/testHelpers/mountTestRenderer.tsx
@@ -29,6 +29,7 @@ export type RendererTestArgs = {
   decorators?: ByPath<ReactDecoratorModule>;
   lazy?: boolean;
   only?: boolean;
+  skip?: boolean;
 };
 
 type RendererTestApi = RendererConnectTestApi & {

--- a/packages/react-cosmos-renderer/src/testHelpers/testRenderer.ts
+++ b/packages/react-cosmos-renderer/src/testHelpers/testRenderer.ts
@@ -11,7 +11,9 @@ export function testRenderer(
 ) {
   const test = () => mountTestRenderer(args, cb);
 
-  if (args.only) {
+  if (args.skip) {
+    it.skip(testName, test);
+  } else if (args.only) {
     it.only(testName, test);
   } else {
     it(testName, test);


### PR DESCRIPTION
> Explain the problem you're solving.

When a HMR causes the fixture to remount*, if props were changed in the fixture source they wouldn't be reflected in the fixture preview because the fixture state for those props would persist and override the changed React element props received with the HMR update.

> \* Causes `FixtureCapture` to remount more specifically, which is where the fixture elements are tracked over time using a ref.

Defaulting `prevFixtureRef` to `null` fixes this but breaks something else: When a fixture is loaded with fixture state (say in a remote renderer), the initial fixture element props override the fixture state (basically the opposite effect). So the question here is: How can we know whether a remount is the first time a fixture loads (and we need to apply any fixture state we might have over it) or whether a remount is a HMR update which could come with props changes (but that we can't compare against the old fixture because the remount blew up the React ref which cointained a reference to the old fixture element).

~~Also oddly `packages/react-cosmos-renderer/src/__tests__/fixtureSelectWithState.tsx` fails locally but not in CI.~~

