### PR TITLE
Fix typo in webpack docs

### DIFF
--- a/docs/pages/docs/getting-started/webpack.mdx
+++ b/docs/pages/docs/getting-started/webpack.mdx
@@ -55,7 +55,7 @@ Cosmos generates a default Webpack config if a custom one isn't provided.
 
 <Callout type="warning">
   Cosmos compiles your code using dependencies you already installed in your
-  project. Cosmos will auto include common loaders like `babal-loader`,
+  project. Cosmos will auto include common loaders like `babel-loader`,
   `ts-loader`, `css-loader`, etc. in the default Webpack config. Use a [custom
   Webpack config](#custom-webpack-config) for more advanced use cases.
 </Callout>


### PR DESCRIPTION
`babal-loader` → `babel-loader`

<img width="716" alt="image" src="https://github.com/react-cosmos/react-cosmos/assets/1355312/34991b0d-f3c1-4e50-8564-f6c01d031105">
