### PR TITLE
Fix broken readme links

### DIFF
--- a/packages/react-cosmos/README.md
+++ b/packages/react-cosmos/README.md
@@ -26,11 +26,11 @@ To chat with other community members you can join the [React Cosmos Discord](htt
 
 You can also ask questions, voice ideas, and share your projects on [GitHub Discussions](https://github.com/react-cosmos/react-cosmos/discussions).
 
-Our [Code of Conduct](/CODE_OF_CONDUCT.md) applies to all React Cosmos community channels.
+Our [Code of Conduct](/.github/CODE_OF_CONDUCT.md) applies to all React Cosmos community channels.
 
 ## Contributing
 
-Please see our [CONTRIBUTING.md](/CONTRIBUTING.md).
+Please see our [CONTRIBUTING.md](/.github/CONTRIBUTING.md).
 
 [Become a Sponsor](https://github.com/sponsors/ovidiuch) to support the ongoing development of React Cosmos.
 


### PR DESCRIPTION
#### Description

- Fixes broken `README.md` `CODE_OF_CONDUCT.md` and `CONTRIBUTING.md` links by changing the absolute path from `/target` to `/.github/target`
