### PR TITLE
Fix fixture export type detection with RSC

### DIFF
--- a/packages/react-cosmos-core/src/userModules/isMultiFixture.ts
+++ b/packages/react-cosmos-core/src/userModules/isMultiFixture.ts
@@ -7,6 +7,12 @@ export function isMultiFixture(
   return (
     fixtureExport !== null &&
     typeof fixtureExport === 'object' &&
-    !isElement(fixtureExport)
+    !isElement(fixtureExport) &&
+    // With React Server Components, fixture exports of Client fixtures are
+    // wrapped in a Promise. The React ComponentType union does include
+    // PromiseLikeOfReactNode but for some reason it's impossible do type
+    // narrowing or use a type predicate function.
+    // @ts-ignore Sadly, we resort to the "cause I said so" type assertion
+    typeof fixtureExport.then !== 'function'
   );
 }

--- a/packages/react-cosmos-core/src/userModules/userModuleTypes.ts
+++ b/packages/react-cosmos-core/src/userModules/userModuleTypes.ts
@@ -1,4 +1,4 @@
-import { ComponentType, FunctionComponent, ReactNode } from 'react';
+import { ComponentType, ReactNode } from 'react';
 
 type FixtureMap<FixtureType> = { [fixtureName: string]: FixtureType };
 type FixtureExport<FixtureType> = FixtureType | FixtureMap<FixtureType>;
@@ -7,7 +7,7 @@ type FixtureModule<FixtureType> = { default: FixtureExport<FixtureType> };
 type ModuleWrapper<ModuleType> = { module: ModuleType };
 type LazyModuleWrapper<ModuleType> = { getModule: () => Promise<ModuleType> };
 
-export type ReactFixture = ReactNode | FunctionComponent;
+export type ReactFixture = ReactNode | ComponentType;
 export type ReactFixtureMap = FixtureMap<ReactFixture>;
 export type ReactFixtureExport = FixtureExport<ReactFixture>;
 export type ReactFixtureModule = FixtureModule<ReactFixture>;

--- a/packages/react-cosmos-renderer/src/fixtureModule/createFixtureNode.tsx
+++ b/packages/react-cosmos-renderer/src/fixtureModule/createFixtureNode.tsx
@@ -1,29 +1,38 @@
-import React from 'react';
+import React, { ComponentType, ReactNode } from 'react';
 import { ReactFixture } from 'react-cosmos-core';
+import { isElement } from 'react-is';
 
 export function createFixtureNode(fixture: ReactFixture): React.ReactNode {
   // Warning: In a React Server Components setup this function is called on the
   // server. When a fixture module uses the 'use client' directive, the fixture
-  // arg received here will be a function wrapper regardless of the fixture
-  // module contents. In this scenario, the fixture module will be automatically
-  // rendered on the client side, where React expects a component default export.
+  // export will be a Promise wrapper (imbued with magical properties methinks).
   // This results in the following limitation: In a React Server Components
   // setup, Client fixtures have to export a single function component. They
   // can't be multi fixtures and they can't export React elements directly.
-  return isFunctionFixture(fixture) ? (
-    <FixtureElement Component={fixture} />
-  ) : (
+  return isNodeFixture(fixture) ? (
     fixture
+  ) : (
+    <FixtureElement Component={fixture} />
   );
 }
 
-function isFunctionFixture(
-  fixture: ReactFixture
-): fixture is React.FunctionComponent {
-  return typeof fixture === 'function';
+function isNodeFixture(fixture: ReactFixture): fixture is ReactNode {
+  // If you're curious what the exact type of ReactNode is:
+  // https://github.com/DefinitelyTyped/DefinitelyTyped/blob/6fc4839a810335dee15374e6bc82dbbc2bbdff58/types/react/index.d.ts#L478-L489
+  return (
+    fixture === undefined ||
+    fixture === null ||
+    typeof fixture === 'string' ||
+    typeof fixture === 'number' ||
+    typeof fixture === 'boolean' ||
+    Array.isArray(fixture) ||
+    // If you're curious what isElement checks:
+    // https://github.com/facebook/react/blob/1b0132c05acabae5aebd32c2cadddfb16bda70bc/packages/react-is/src/ReactIs.js#L108-L114
+    isElement(fixture)
+  );
 }
 
-function FixtureElement({ Component }: { Component: React.FunctionComponent }) {
+function FixtureElement({ Component }: { Component: ComponentType }) {
   return <Component />;
 }
 FixtureElement.cosmosCapture = false;


### PR DESCRIPTION
#1639

Fixes handling of Promise exports from Client fixtures when using React Server Components.