### PR TITLE
Make getFixtures async

### DIFF
--- a/docs/pages/docs/node-api.mdx
+++ b/docs/pages/docs/node-api.mdx
@@ -68,7 +68,7 @@ Get all your fixtures programatically. A ton of information is provided for each
 ```js
 import { getFixtures } from 'react-cosmos';
 
-const fixtures = getFixtures(cosmosConfig, {
+const fixtures = await getFixtures(cosmosConfig, {
   rendererUrl: 'http://localhost:5000/renderer.html',
 });
 
@@ -99,7 +99,5 @@ Jest brings an array of problems due to its limitations:
 
 1. [ESM support is unfinished.](https://github.com/jestjs/jest/issues/9430)
 2. [You can't create test cases asynchronously.](https://github.com/jestjs/jest/issues/2235#issuecomment-584387443) Using an async `globalSetup` [could work](https://github.com/jestjs/jest/issues/2235#issuecomment-584387443), but it can't import ESM and we're back to square one.
-
-For the reasons above `getFixtures()` is a synchronous API. It uses CommonJS `require()` to import user modules.
 
 Another limitation due to the lack of ESM support in Jest is the fact that `getFixtures()` doesn't incorporate Cosmos server plugins. The config hooks of server plugins usually auto-set the `rendererUrl` option in the user's Cosmos config. The Vite and Webpack plugins do this. With `getFixtures()`, however, we pass the renderer URL as a separate option after the Cosmos config.

--- a/packages/react-cosmos-plugin-vite/src/reactCosmosViteRollupPlugin.ts
+++ b/packages/react-cosmos-plugin-vite/src/reactCosmosViteRollupPlugin.ts
@@ -33,9 +33,9 @@ export function reactCosmosViteRollupPlugin(
       }
     },
 
-    load(id: string) {
+    async load(id: string) {
       if (id == userImportsResolvedModuleId) {
-        const modulePaths = findUserModulePaths(cosmosConfig);
+        const modulePaths = await findUserModulePaths(cosmosConfig);
         return generateUserImports<DomRendererConfig>({
           cosmosConfig,
           modulePaths,

--- a/packages/react-cosmos-plugin-webpack/src/server/webpackConfig/userImportsLoader.cjs
+++ b/packages/react-cosmos-plugin-webpack/src/server/webpackConfig/userImportsLoader.cjs
@@ -17,7 +17,7 @@ module.exports = async function injectUserImports() {
   watchDirs.forEach(watchDir => this.addContextDependency(watchDir));
 
   const { containerQuerySelector } = cosmosConfig.dom;
-  const modulePaths = cosmos.findUserModulePaths(cosmosConfig);
+  const modulePaths = await cosmos.findUserModulePaths(cosmosConfig);
   const rendererConfig = {
     playgroundUrl: cosmos.getPlaygroundUrl(cosmosConfig),
     containerQuerySelector,

--- a/packages/react-cosmos/src/corePlugins/fixtureWatcherPlugin.ts
+++ b/packages/react-cosmos/src/corePlugins/fixtureWatcherPlugin.ts
@@ -22,12 +22,12 @@ export const fixtureWatcherPlugin: CosmosServerPlugin = {
     const exposeImports = shouldExposeImports(platform, cosmosConfig);
 
     if (exposeImports) {
-      const modulePaths = findUserModulePaths(cosmosConfig);
+      const modulePaths = await findUserModulePaths(cosmosConfig);
       await generateImportsFile(cosmosConfig, 'dev', modulePaths);
     }
 
-    const watcher = await startFixtureWatcher(cosmosConfig, 'all', () => {
-      const modulePaths = findUserModulePaths(cosmosConfig);
+    const watcher = await startFixtureWatcher(cosmosConfig, 'all', async () => {
+      const modulePaths = await findUserModulePaths(cosmosConfig);
 
       updateFixtureListCache(cosmosConfig.rootDir, modulePaths.fixturePaths);
 
@@ -43,7 +43,7 @@ export const fixtureWatcherPlugin: CosmosServerPlugin = {
 
   async export({ cosmosConfig }) {
     if (shouldExposeImports('web', cosmosConfig)) {
-      const modulePaths = findUserModulePaths(cosmosConfig);
+      const modulePaths = await findUserModulePaths(cosmosConfig);
       await generateImportsFile(cosmosConfig, 'export', modulePaths);
     }
   },

--- a/packages/react-cosmos/src/corePlugins/fixturesJsonPlugin.ts
+++ b/packages/react-cosmos/src/corePlugins/fixturesJsonPlugin.ts
@@ -31,15 +31,15 @@ export const fixturesJsonPlugin: CosmosServerPlugin = {
   devServer({ cosmosConfig, expressApp }) {
     expressApp.get(
       '/cosmos.fixtures.json',
-      (req: express.Request, res: express.Response) => {
-        res.json(createFixtureItems(cosmosConfig, 'dev'));
+      async (req: express.Request, res: express.Response) => {
+        res.json(await createFixtureItems(cosmosConfig, 'dev'));
       }
     );
   },
 
   async export({ cosmosConfig }) {
     const { exportPath } = cosmosConfig;
-    const json = createFixtureItems(cosmosConfig, 'export');
+    const json = await createFixtureItems(cosmosConfig, 'export');
     await fs.writeFile(
       path.join(exportPath, 'cosmos.fixtures.json'),
       JSON.stringify(json, null, 2)
@@ -47,10 +47,10 @@ export const fixturesJsonPlugin: CosmosServerPlugin = {
   },
 };
 
-function createFixtureItems(
+async function createFixtureItems(
   cosmosConfig: CosmosConfig,
   command: CosmosCommand
-): CosmosFixturesJson {
+): Promise<CosmosFixturesJson> {
   const rendererUrl = pickRendererUrl(cosmosConfig.rendererUrl, command);
   if (!rendererUrl) {
     return {
@@ -60,7 +60,7 @@ function createFixtureItems(
   }
 
   const { fixturesDir, fixtureFileSuffix } = cosmosConfig;
-  const { fixturePaths } = findUserModulePaths(cosmosConfig);
+  const { fixturePaths } = await findUserModulePaths(cosmosConfig);
 
   const fixtures = fixturePaths.map(filePath => {
     const relPath = importKeyPath(filePath, cosmosConfig.rootDir);

--- a/packages/react-cosmos/src/getFixtures/getFixtures.test.ts
+++ b/packages/react-cosmos/src/getFixtures/getFixtures.test.ts
@@ -10,7 +10,7 @@ it('renders fixture elements', async () => {
     ignore: ['**/*.mdx'],
   });
 
-  const fixures = getFixtures(cosmosConfig, {
+  const fixures = await getFixtures(cosmosConfig, {
     rendererUrl: 'http://localhost:5000/renderer.html',
   });
 

--- a/packages/react-cosmos/src/getFixtures/getFixtures.test.ts
+++ b/packages/react-cosmos/src/getFixtures/getFixtures.test.ts
@@ -31,7 +31,7 @@ it('returns fixture info', async () => {
     ignore: ['**/*.mdx'],
   });
 
-  const fixtures = getFixtures(cosmosConfig, {
+  const fixtures = await getFixtures(cosmosConfig, {
     rendererUrl: 'http://localhost:5000/renderer.html',
   });
 

--- a/packages/react-cosmos/src/getFixtures/getFixtures.ts
+++ b/packages/react-cosmos/src/getFixtures/getFixtures.ts
@@ -35,8 +35,11 @@ export type FixtureApi = {
 type Options = {
   rendererUrl?: string;
 };
-export function getFixtures(cosmosConfig: CosmosConfig, options: Options = {}) {
-  const { fixtures, decorators } = importUserModules(cosmosConfig);
+export async function getFixtures(
+  cosmosConfig: CosmosConfig,
+  options: Options = {}
+) {
+  const { fixtures, decorators } = await importUserModules(cosmosConfig);
   const fixtureExports = mapValues(fixtures, f => f.default);
   const decoratorExports = mapValues(decorators, f => f.default);
   const result: FixtureApi[] = [];

--- a/packages/react-cosmos/src/shared/playgroundHtml.ts
+++ b/packages/react-cosmos/src/shared/playgroundHtml.ts
@@ -24,7 +24,7 @@ export async function getDevPlaygroundHtml(
       ...ui,
       core: await getCoreConfig(cosmosConfig, true),
       rendererCore: {
-        fixtures: getServerFixtureList(cosmosConfig),
+        fixtures: await getServerFixtureList(cosmosConfig),
         rendererUrl:
           platform === 'web'
             ? pickRendererUrl(cosmosConfig.rendererUrl, 'dev')
@@ -45,7 +45,7 @@ export async function getExportPlaygroundHtml(
       ...ui,
       core: await getCoreConfig(cosmosConfig, false),
       rendererCore: {
-        fixtures: getServerFixtureList(cosmosConfig),
+        fixtures: await getServerFixtureList(cosmosConfig),
         rendererUrl: pickRendererUrl(cosmosConfig.rendererUrl, 'export'),
       },
     },

--- a/packages/react-cosmos/src/shared/serverFixtureList.ts
+++ b/packages/react-cosmos/src/shared/serverFixtureList.ts
@@ -5,9 +5,9 @@ import { importKeyPath } from '../userModules/shared.js';
 
 let fixtureListCache: FixtureList | null = null;
 
-export function getServerFixtureList(cosmosConfig: CosmosConfig) {
+export async function getServerFixtureList(cosmosConfig: CosmosConfig) {
   if (!fixtureListCache) {
-    const { fixturePaths } = findUserModulePaths(cosmosConfig);
+    const { fixturePaths } = await findUserModulePaths(cosmosConfig);
     fixtureListCache = createFixtureList(cosmosConfig.rootDir, fixturePaths);
   }
 

--- a/packages/react-cosmos/src/userModules/findUserModulePaths.ts
+++ b/packages/react-cosmos/src/userModules/findUserModulePaths.ts
@@ -1,4 +1,4 @@
-import { globSync } from 'glob';
+import { glob } from 'glob';
 import micromatch from 'micromatch';
 import {
   UserModulePaths,
@@ -12,13 +12,13 @@ type FindUserModulePathsArgs = {
   fixtureFileSuffix: string;
   ignore: string[];
 };
-export function findUserModulePaths({
+export async function findUserModulePaths({
   rootDir,
   fixturesDir,
   fixtureFileSuffix,
   ignore,
-}: FindUserModulePathsArgs): UserModulePaths {
-  const paths = globSync('**/*', {
+}: FindUserModulePathsArgs): Promise<UserModulePaths> {
+  const paths = await glob('**/*', {
     cwd: rootDir,
     absolute: true,
     ignore,


### PR DESCRIPTION
This gets rid of the last CJS `require()` in Cosmos packages.