### PR TITLE
refactor: migrate from NativeModule to TurboModuleRegistry

### DIFF
--- a/packages/react-cosmos-native/src/getSocketUrl.test.ts
+++ b/packages/react-cosmos-native/src/getSocketUrl.test.ts
@@ -2,11 +2,13 @@ import { vi } from 'vitest';
 import { getSocketUrl } from './getSocketUrl.js';
 
 vi.mock('react-native', () => ({
-  NativeModules: {
-    SourceCode: {
-      scriptURL:
-        'http://192.168.100.65:8081/index.bundle?platform=ios&dev=true&hot=false',
-    },
+  TurboModuleRegistry: {
+    getEnforcing: () => ({
+      getConstants: () => ({
+        scriptURL:
+          'http://192.168.100.65:8081/index.bundle?platform=ios&dev=true&hot=false',
+      }),
+    }),
   },
 }));
 

--- a/packages/react-cosmos-native/src/getSocketUrl.ts
+++ b/packages/react-cosmos-native/src/getSocketUrl.ts
@@ -1,11 +1,11 @@
-import * as ReactNative from 'react-native';
-
-const { NativeModules } = ReactNative;
+import { TurboModuleRegistry } from 'react-native';
 
 export function getSocketUrl(playgroundUrl: string) {
   // The URL module isn't implemented fully in React Native and I don't want to
   // bring in another dependency just for this.
-  const scriptURL = NativeModules.SourceCode.scriptURL as string;
+  const sourceCode = TurboModuleRegistry.getEnforcing('SourceCode');
+  const constants = sourceCode.getConstants?.() as any;
+  const scriptURL = constants.scriptURL as string;
 
   // https://stackoverflow.com/a/27755/1332513
   const urlRegex = /^(.*:)\/\/([A-Za-z0-9\-\.]+)(:[0-9]+)?(.*)$/;


### PR DESCRIPTION
## Context

Expo 52 seems to have changed how it deals with the NativeModules, probably because of defaulting to the new architecture. This migrates the `getSocketURL` to use TurboModuleRegistry, which works with both architectures consistently.

## Testing

I've tested on an expo project with and without the new architecture, both rendered correctly.

I have not tested on a pure RN project but it *should* work, would appreciate if someone with a project that knowingly has this issue pitched in so that we can validate if this fix works.

I tried to keep things as much as they were and I'm open to any and all criticism :)