### PR TITLE
Update decorator docs with global CSS import guidance

### DIFF
--- a/docs/pages/docs/fixtures/decorators.mdx
+++ b/docs/pages/docs/fixtures/decorators.mdx
@@ -30,3 +30,22 @@ A decorator file can also export an array of decorators:
 ```jsx filename="cosmos.decorator.js"
 export default [Decorator1, Decorator2, Decorator3];
 ```
+
+## Importing Global CSS
+
+For styles that need to be applied globally—such as `normalize.css`, global variables, or other design system styles—it is recommended **not** to import them inside a decorator. Importing CSS files in a decorator may result in their styles being appended after your fixture styles, which can lead to unexpected styling issues.
+
+Instead, add these CSS files to the `globalImports` array in your [cosmos.config.json](https://reactcosmos.org/docs/configuration/cosmos-config). For example:
+
+```json
+{
+  "plugins": ["…"],
+  "globalImports": [
+    "normalize.css",
+    "./src/design-system/global-variables.css",
+    "./src/design-system/global.css"
+  ]
+}
+```
+
+This ensures that your global CSS is loaded before any fixture-specific styles, maintaining the intended cascade.


### PR DESCRIPTION
Added instructions to import global CSS (e.g., normalize.css) via the `globalImports` option in the Cosmos config.

### Explanation of the Problem We Were Solving

When using React Cosmos, importing global CSS files (like `normalize.css`) within a decorator file can lead to unintended styling issues. Specifically, these styles end up being appended after fixture-specific styles, which disrupts the intended CSS cascade. This can cause global styles to override fixture styles, potentially leading to inconsistent or unexpected UI behavior.

To address this issue, the solution was to move the import of global CSS files out of the decorator and instead add them to the `globalImports` array in the Cosmos configuration. This ensures that the global CSS is loaded first, establishing a consistent base for all subsequent styles in the application.

By making this change, we improve the clarity of the documentation and provide a clear, recommended approach for handling global CSS in React Cosmos projects.
