### PR TITLE
Differ playground URL params from renderer URL params

### DIFF
--- a/packages/react-cosmos-core/src/playground/playgroundParams.ts
+++ b/packages/react-cosmos-core/src/playground/playgroundParams.ts
@@ -1,5 +1,5 @@
 import { FixtureId } from '../userModules/fixtureTypes.js';
 
 export type PlaygroundParams = {
-  fixtureId?: FixtureId;
+  fixture?: FixtureId;
 };

--- a/packages/react-cosmos-core/src/playground/playgroundQueryString.ts
+++ b/packages/react-cosmos-core/src/playground/playgroundQueryString.ts
@@ -2,7 +2,7 @@ import { buildQueryString, parseQueryString } from '../utils/queryString.js';
 import { PlaygroundParams } from './playgroundParams.js';
 
 type SearchParams = {
-  fixtureId?: string;
+  fixture?: string;
 };
 
 export function buildPlaygroundQueryString(params: PlaygroundParams) {
@@ -16,8 +16,8 @@ export function parsePlaygroundQueryString(query: string) {
 function encodePlaygroundSearchParams(params: PlaygroundParams) {
   const stringParams: SearchParams = {};
 
-  if (params.fixtureId) {
-    stringParams.fixtureId = JSON.stringify(params.fixtureId);
+  if (params.fixture) {
+    stringParams.fixture = JSON.stringify(params.fixture);
   }
 
   return stringParams;
@@ -26,8 +26,8 @@ function encodePlaygroundSearchParams(params: PlaygroundParams) {
 function decodePlaygroundSearchParams(stringParams: SearchParams) {
   const params: PlaygroundParams = {};
 
-  if (stringParams.fixtureId) {
-    params.fixtureId = JSON.parse(stringParams.fixtureId);
+  if (stringParams.fixture) {
+    params.fixture = JSON.parse(stringParams.fixture);
   }
 
   return params;

--- a/packages/react-cosmos-ui/src/plugins/FixtureBookmark/FixtureBookmarks.tsx
+++ b/packages/react-cosmos-ui/src/plugins/FixtureBookmark/FixtureBookmarks.tsx
@@ -62,7 +62,7 @@ export function FixtureBookmarks({
         return (
           <ListItem key={itemKey} selected={selected}>
             <FixtureLink
-              href={createRelativePlaygroundUrl({ fixtureId })}
+              href={createRelativePlaygroundUrl({ fixture: fixtureId })}
               selected={selected}
               onClick={handleClick}
             >

--- a/packages/react-cosmos-ui/src/plugins/FixtureTree/FixtureTree/FixtureLink.tsx
+++ b/packages/react-cosmos-ui/src/plugins/FixtureTree/FixtureTree/FixtureLink.tsx
@@ -13,7 +13,7 @@ type Props = {
 export function FixtureLink({ children, fixtureId, onSelect }: Props) {
   return (
     <Link
-      href={createRelativePlaygroundUrl({ fixtureId })}
+      href={createRelativePlaygroundUrl({ fixture: fixtureId })}
       onClick={e => {
         e.preventDefault();
         if (e.metaKey) openAnchorInNewTab(e.currentTarget);

--- a/packages/react-cosmos-ui/src/plugins/Router/__tests__/getSelectedFixtureId.ts
+++ b/packages/react-cosmos-ui/src/plugins/Router/__tests__/getSelectedFixtureId.ts
@@ -17,7 +17,7 @@ afterEach(() => {
 const fixtureId = { path: 'zwei.js' };
 
 it('returns fixtureId', async () => {
-  pushUrlParams({ fixtureId: JSON.stringify(fixtureId) });
+  pushUrlParams({ fixture: JSON.stringify(fixtureId) });
   loadPlugins();
 
   await waitFor(() =>

--- a/packages/react-cosmos-ui/src/plugins/Router/__tests__/initialFixture.ts
+++ b/packages/react-cosmos-ui/src/plugins/Router/__tests__/initialFixture.ts
@@ -43,7 +43,7 @@ it('sets URL params from initial fixture config', async () => {
   });
 
   await waitFor(() =>
-    expect(getUrlParams()).toEqual({ fixtureId: JSON.stringify(fixtureId) })
+    expect(getUrlParams()).toEqual({ fixture: JSON.stringify(fixtureId) })
   );
 });
 
@@ -67,7 +67,7 @@ it('selects URL fixture param over initial fixture config', async () => {
   const urlFixtureId = { path: 'ein.js' };
   const configFixtureId = { path: 'zwei.js' };
 
-  pushUrlParams({ fixtureId: JSON.stringify(urlFixtureId) });
+  pushUrlParams({ fixture: JSON.stringify(urlFixtureId) });
   loadPlugins({
     config: {
       router: {

--- a/packages/react-cosmos-ui/src/plugins/Router/__tests__/selectFixture.ts
+++ b/packages/react-cosmos-ui/src/plugins/Router/__tests__/selectFixture.ts
@@ -32,7 +32,7 @@ it('sets URL params', async () => {
   getRouterMethods().selectFixture(fixtureId);
 
   await waitFor(() =>
-    expect(getUrlParams()).toEqual({ fixtureId: JSON.stringify(fixtureId) })
+    expect(getUrlParams()).toEqual({ fixture: JSON.stringify(fixtureId) })
   );
 });
 

--- a/packages/react-cosmos-ui/src/plugins/Router/__tests__/unselectFixture.ts
+++ b/packages/react-cosmos-ui/src/plugins/Router/__tests__/unselectFixture.ts
@@ -21,7 +21,7 @@ afterEach(() => {
 const fixtureId = { path: 'zwei.js' };
 
 function loadTestPlugins() {
-  pushUrlParams({ fixtureId: JSON.stringify(fixtureId) });
+  pushUrlParams({ fixture: JSON.stringify(fixtureId) });
   loadPlugins();
 }
 

--- a/packages/react-cosmos-ui/src/plugins/Router/__tests__/urlChange.ts
+++ b/packages/react-cosmos-ui/src/plugins/Router/__tests__/urlChange.ts
@@ -20,7 +20,7 @@ it('emits "fixtureSelect" event on "fixtureId" URL param change', () => {
   const { fixtureSelect } = onRouter();
 
   loadPlugins();
-  popUrlParams({ fixtureId: JSON.stringify(fixtureId) });
+  popUrlParams({ fixture: JSON.stringify(fixtureId) });
 
   expect(fixtureSelect).toBeCalledWith(expect.any(Object), fixtureId);
 });
@@ -28,7 +28,7 @@ it('emits "fixtureSelect" event on "fixtureId" URL param change', () => {
 it('emits "fixtureUnselect" event on removed "fixtureId" URL param', async () => {
   const { fixtureUnselect } = onRouter();
 
-  pushUrlParams({ fixtureId: JSON.stringify(fixtureId) });
+  pushUrlParams({ fixture: JSON.stringify(fixtureId) });
   loadPlugins();
 
   // This simulation is akin to going back home after selecting a fixture

--- a/packages/react-cosmos-ui/src/plugins/Router/index.ts
+++ b/packages/react-cosmos-ui/src/plugins/Router/index.ts
@@ -32,13 +32,13 @@ onLoad(context => {
   setState({ urlParams });
 
   const { initialFixtureId } = getConfig();
-  if (initialFixtureId && !urlParams.fixtureId) {
+  if (initialFixtureId && !urlParams.fixture) {
     selectFixture(context, initialFixtureId);
   }
 
   return subscribeToLocationChanges((nextUrlParams: PlaygroundParams) => {
-    const { fixtureId } = context.getState().urlParams;
-    const fixtureChanged = !isEqual(nextUrlParams.fixtureId, fixtureId);
+    const { fixture } = context.getState().urlParams;
+    const fixtureChanged = !isEqual(nextUrlParams.fixture, fixture);
 
     setState({ urlParams: nextUrlParams }, () => {
       if (fixtureChanged) {
@@ -53,11 +53,11 @@ export { register };
 if (process.env.NODE_ENV !== 'test') register();
 
 function getSelectedFixtureId({ getState }: RouterContext) {
-  return getState().urlParams.fixtureId || null;
+  return getState().urlParams.fixture || null;
 }
 
 function selectFixture(context: RouterContext, fixtureId: FixtureId) {
-  setUrlParams(context, { fixtureId });
+  setUrlParams(context, { fixture: fixtureId });
 }
 
 function unselectFixture(context: RouterContext) {
@@ -66,7 +66,7 @@ function unselectFixture(context: RouterContext) {
 
 function setUrlParams(context: RouterContext, nextUrlParams: PlaygroundParams) {
   const { urlParams } = context.getState();
-  const fixtureChanged = !isEqual(nextUrlParams.fixtureId, urlParams.fixtureId);
+  const fixtureChanged = !isEqual(nextUrlParams.fixture, urlParams.fixture);
   const urlParamsEqual = isEqual(nextUrlParams, urlParams);
 
   if (urlParamsEqual) {

--- a/packages/react-cosmos/src/getFixtures/getFixtures.test.ts
+++ b/packages/react-cosmos/src/getFixtures/getFixtures.test.ts
@@ -50,7 +50,7 @@ it('returns fixture info', async () => {
       rendererUrl:
         'http://localhost:5000/renderer.html?fixtureId=%7B%22path%22%3A%22src%2F__fixtures__%2Fcontrols%2FInputs+Panel.tsx%22%7D',
       playgroundUrl:
-        'http://localhost:5000/?fixtureId=%7B%22path%22%3A%22src%2F__fixtures__%2Fcontrols%2FInputs+Panel.tsx%22%7D',
+        'http://localhost:5000/?fixture=%7B%22path%22%3A%22src%2F__fixtures__%2Fcontrols%2FInputs+Panel.tsx%22%7D',
       treePath: ['controls', 'Inputs Panel'],
     },
     {
@@ -66,7 +66,7 @@ it('returns fixture info', async () => {
       rendererUrl:
         'http://localhost:5000/renderer.html?fixtureId=%7B%22path%22%3A%22src%2F__fixtures__%2Fcontrols%2FProps+Panel.tsx%22%7D',
       playgroundUrl:
-        'http://localhost:5000/?fixtureId=%7B%22path%22%3A%22src%2F__fixtures__%2Fcontrols%2FProps+Panel.tsx%22%7D',
+        'http://localhost:5000/?fixture=%7B%22path%22%3A%22src%2F__fixtures__%2Fcontrols%2FProps+Panel.tsx%22%7D',
       treePath: ['controls', 'Props Panel'],
     },
     {
@@ -76,7 +76,7 @@ it('returns fixture info', async () => {
       name: 'default',
       parents: [],
       playgroundUrl:
-        'http://localhost:5000/?fixtureId=%7B%22path%22%3A%22src%2FCounter.fixture.tsx%22%2C%22name%22%3A%22default%22%7D',
+        'http://localhost:5000/?fixture=%7B%22path%22%3A%22src%2FCounter.fixture.tsx%22%2C%22name%22%3A%22default%22%7D',
       relativeFilePath: 'src/Counter.fixture.tsx',
       rendererUrl:
         'http://localhost:5000/renderer.html?fixtureId=%7B%22path%22%3A%22src%2FCounter.fixture.tsx%22%2C%22name%22%3A%22default%22%7D',
@@ -89,7 +89,7 @@ it('returns fixture info', async () => {
       name: 'small number',
       parents: [],
       playgroundUrl:
-        'http://localhost:5000/?fixtureId=%7B%22path%22%3A%22src%2FCounter.fixture.tsx%22%2C%22name%22%3A%22small+number%22%7D',
+        'http://localhost:5000/?fixture=%7B%22path%22%3A%22src%2FCounter.fixture.tsx%22%2C%22name%22%3A%22small+number%22%7D',
       relativeFilePath: 'src/Counter.fixture.tsx',
       rendererUrl:
         'http://localhost:5000/renderer.html?fixtureId=%7B%22path%22%3A%22src%2FCounter.fixture.tsx%22%2C%22name%22%3A%22small+number%22%7D',
@@ -102,7 +102,7 @@ it('returns fixture info', async () => {
       name: 'large number',
       parents: [],
       playgroundUrl:
-        'http://localhost:5000/?fixtureId=%7B%22path%22%3A%22src%2FCounter.fixture.tsx%22%2C%22name%22%3A%22large+number%22%7D',
+        'http://localhost:5000/?fixture=%7B%22path%22%3A%22src%2FCounter.fixture.tsx%22%2C%22name%22%3A%22large+number%22%7D',
       relativeFilePath: 'src/Counter.fixture.tsx',
       rendererUrl:
         'http://localhost:5000/renderer.html?fixtureId=%7B%22path%22%3A%22src%2FCounter.fixture.tsx%22%2C%22name%22%3A%22large+number%22%7D',
@@ -115,7 +115,7 @@ it('returns fixture info', async () => {
       name: null,
       parents: [],
       playgroundUrl:
-        'http://localhost:5000/?fixtureId=%7B%22path%22%3A%22src%2FCounterButton.fixture.tsx%22%7D',
+        'http://localhost:5000/?fixture=%7B%22path%22%3A%22src%2FCounterButton.fixture.tsx%22%7D',
       relativeFilePath: 'src/CounterButton.fixture.tsx',
       rendererUrl:
         'http://localhost:5000/renderer.html?fixtureId=%7B%22path%22%3A%22src%2FCounterButton.fixture.tsx%22%7D',
@@ -131,7 +131,7 @@ it('returns fixture info', async () => {
       name: null,
       parents: [],
       playgroundUrl:
-        'http://localhost:5000/?fixtureId=%7B%22path%22%3A%22src%2FWelcomeMessage%2FWelcomeMessage.fixture.tsx%22%7D',
+        'http://localhost:5000/?fixture=%7B%22path%22%3A%22src%2FWelcomeMessage%2FWelcomeMessage.fixture.tsx%22%7D',
       relativeFilePath: 'src/WelcomeMessage/WelcomeMessage.fixture.tsx',
       rendererUrl:
         'http://localhost:5000/renderer.html?fixtureId=%7B%22path%22%3A%22src%2FWelcomeMessage%2FWelcomeMessage.fixture.tsx%22%7D',

--- a/packages/react-cosmos/src/getFixtures/getFixtures.ts
+++ b/packages/react-cosmos/src/getFixtures/getFixtures.ts
@@ -100,7 +100,7 @@ function getPlaygroundFixtureUrl(
   fixtureId: FixtureId
 ) {
   const baseUrl = getPlaygroundUrl(cosmosConfig);
-  const query = buildPlaygroundQueryString({ fixtureId });
+  const query = buildPlaygroundQueryString({ fixture: fixtureId });
   return `${baseUrl}/${query}`;
 }
 


### PR DESCRIPTION
This change improves the experience of loading Cosmos (UI) inside Cosmos (renderer).
