### PR TITLE
Bump `@skidding/launch-editor` to track upstream 2.13.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4606,76 +4606,12 @@
       }
     },
     "node_modules/@skidding/launch-editor": {
-      "version": "2.2.3",
-      "resolved": "https://registry.npmjs.org/@skidding/launch-editor/-/launch-editor-2.2.3.tgz",
-      "integrity": "sha512-0SuGEsWdulnbryUJ6humogFuuDMWMb4VJyhOc3FGVkibxVdECYDDkGx8VjS/NePZSegNONDIVhCEVZLTv4ycTQ==",
+      "version": "2.13.2",
+      "resolved": "https://registry.npmjs.org/@skidding/launch-editor/-/launch-editor-2.13.2.tgz",
+      "integrity": "sha512-BphfE/1Prmsjj5K7mZzKU5wHf360pu7CdylfR6UqRHrzw/qMgqnQA/0yTDHDe1VsPuGpQt2QeSbbu48WY4bj0g==",
+      "license": "MIT",
       "dependencies": {
-        "chalk": "^2.3.0",
-        "shell-quote": "^1.6.1"
-      }
-    },
-    "node_modules/@skidding/launch-editor/node_modules/ansi-styles": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-      "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-      "dependencies": {
-        "color-convert": "^1.9.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/@skidding/launch-editor/node_modules/chalk": {
-      "version": "2.4.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-      "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-      "dependencies": {
-        "ansi-styles": "^3.2.1",
-        "escape-string-regexp": "^1.0.5",
-        "supports-color": "^5.3.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/@skidding/launch-editor/node_modules/color-convert": {
-      "version": "1.9.3",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
-      "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-      "dependencies": {
-        "color-name": "1.1.3"
-      }
-    },
-    "node_modules/@skidding/launch-editor/node_modules/color-name": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-      "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw=="
-    },
-    "node_modules/@skidding/launch-editor/node_modules/escape-string-regexp": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-      "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
-      "engines": {
-        "node": ">=0.8.0"
-      }
-    },
-    "node_modules/@skidding/launch-editor/node_modules/has-flag": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-      "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/@skidding/launch-editor/node_modules/supports-color": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-      "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-      "dependencies": {
-        "has-flag": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=4"
+        "shell-quote": "^1.8.3"
       }
     },
     "node_modules/@skidding/linked-list": {
@@ -18926,9 +18862,10 @@
       }
     },
     "node_modules/shell-quote": {
-      "version": "1.8.2",
-      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.2.tgz",
-      "integrity": "sha512-AzqKpGKjrj7EM6rKVQEPpB288oCfnrEIuyoT9cyF4nmGa7V8Zk6f7RRqYisX8X9m+Q7bd632aZW4ky7EhbQztA==",
+      "version": "1.8.3",
+      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.3.tgz",
+      "integrity": "sha512-ObmnIF4hXNg1BqhnHmgbDETF8dLPCggZWBjkQfhZpbszZnYur5DUljTcCHii5LC3J5E0yeO/1LIMyH+UvHQgyw==",
+      "license": "MIT",
       "engines": {
         "node": ">= 0.4"
       },
@@ -21970,7 +21907,7 @@
       "version": "7.2.0",
       "license": "MIT",
       "dependencies": {
-        "@skidding/launch-editor": "2.2.3",
+        "@skidding/launch-editor": "2.13.2",
         "chokidar": "3.6.0",
         "express": "4.22.1",
         "glob": "10.5.0",

--- a/packages/react-cosmos/package.json
+++ b/packages/react-cosmos/package.json
@@ -7,7 +7,7 @@
   "type": "module",
   "main": "./index.js",
   "dependencies": {
-    "@skidding/launch-editor": "2.2.3",
+    "@skidding/launch-editor": "2.13.2",
     "chokidar": "3.6.0",
     "express": "4.22.1",
     "glob": "10.5.0",


### PR DESCRIPTION
"Open fixture source" was launching vim inside the dev server's terminal instead of opening VS Code. Root cause: the fork was stuck on upstream 2.2.1 (2018), whose macOS editor detection only looks for VS Code at `.../MacOS/Electron` — but Microsoft renamed that binary to `Code` years ago. Detection missed VS Code, fell through to `$EDITOR`, and spawned vim with inherited stdio.

Syncing to upstream 2.13.2 picks up the `Code` binary path plus detection for Cursor, VSCodium, Zed, WebStorm Ultimate/CE, MacVim, and others. Also gains Windows CMD RCE hardening, `file://` URL support, and the `LAUNCH_EDITOR` env var as an explicit override. The fork's only local patch (silencing `wrapErrorCallback`'s stdout spam so react-cosmos can fall back to `open()` cleanly) is preserved.
