### PR TITLE
Fix Fast Refresh inside iframe by preserving existing devtools hook

### DIFF
--- a/packages/react-cosmos-plugin-webpack/src/client/reactDevtoolsHook.ts
+++ b/packages/react-cosmos-plugin-webpack/src/client/reactDevtoolsHook.ts
@@ -1,18 +1,33 @@
-// TLDR: This has to be done before React is imported
-// https://github.com/facebook/react-devtools/issues/76#issuecomment-128091900
-// More context: User-defined "global imports" have to be imported *after* this
-// file (because they can import React), but *before* the main renderer entry
-// point (because the user's global imports have to take effect before we
-// import fixture and decorator modules). For this reason this file has to be
-// imported by hand in each renderer implementation.
-// @ts-ignore
+// Legacy fallback: copies the parent frame's React DevTools hook into this
+// frame so the parent's DevTools instance can see React in the iframe. This
+// predates the modern React DevTools extension, which auto-injects its hook
+// into every frame on its own (facebook/react-devtools#76 was filed against
+// the original, now-archived extension). It's effectively a no-op in current
+// browsers — kept as a fallback for setups where neither DevTools nor React
+// Refresh has installed a hook.
+//
+// Wiring constraint: this file is imported by hand in each renderer
+// implementation. It must run *before* both user-defined global imports
+// (which may import React) and the main renderer entry (which imports
+// fixtures and decorators) — anything that imports React after this file
+// will see the hook we put in place.
 if (process.env.NODE_ENV === 'development') {
+  type DevtoolsWindow = Window & {
+    __REACT_DEVTOOLS_GLOBAL_HOOK__?: unknown;
+  };
+  const ownWindow = window as DevtoolsWindow;
   // Accessing the parent window can throw when loading a static export without
   // a web server (i.e. via file:/// protocol)
   try {
-    (window as any).__REACT_DEVTOOLS_GLOBAL_HOOK__ = (
-      window.parent as any
-    ).__REACT_DEVTOOLS_GLOBAL_HOOK__;
+    // Skip when this frame already has a hook — either DevTools auto-injected
+    // it, or React Refresh installed a patched stub. Overwriting that stub
+    // would drop the patches and silently break Fast Refresh inside the
+    // iframe (HMR completes but components never re-render).
+    if (!ownWindow.__REACT_DEVTOOLS_GLOBAL_HOOK__) {
+      const parentWindow = window.parent as DevtoolsWindow;
+      ownWindow.__REACT_DEVTOOLS_GLOBAL_HOOK__ =
+        parentWindow.__REACT_DEVTOOLS_GLOBAL_HOOK__;
+    }
   } catch {
     console.warn('Could not access parent React devtools hook');
   }

--- a/packages/react-cosmos-plugin-webpack/src/client/reactDevtoolsHook.ts
+++ b/packages/react-cosmos-plugin-webpack/src/client/reactDevtoolsHook.ts
@@ -6,11 +6,10 @@
 // browsers — kept as a fallback for setups where neither DevTools nor React
 // Refresh has installed a hook.
 //
-// Wiring constraint: this file is imported by hand in each renderer
-// implementation. It must run *before* both user-defined global imports
-// (which may import React) and the main renderer entry (which imports
-// fixtures and decorators) — anything that imports React after this file
-// will see the hook we put in place.
+// Wiring constraint: this file must run *before* both user-defined global
+// imports (which may import React) and the main renderer entry (which
+// imports fixtures and decorators) — anything that imports React after
+// this file will see the hook we put in place.
 if (process.env.NODE_ENV === 'development') {
   type DevtoolsWindow = Window & {
     __REACT_DEVTOOLS_GLOBAL_HOOK__?: unknown;


### PR DESCRIPTION
reactDevtoolsHook unconditionally overwrote window.__REACT_DEVTOOLS_GLOBAL_HOOK__ with the parent frame's hook. When react-refresh-webpack-plugin's prepended entry had already patched that hook, the overwrite dropped the patches — so React's scheduleRefresh helpers were never captured and HMR completed but components never re-rendered. Skip the overwrite when this frame already has a hook (DevTools auto-injected or React Refresh's stub).

Also modernize the types: replace the (window as any) casts with a typed Window alias matching WebpackHotClientWindow in the same folder, use unknown since this file never calls into the hook, and drop the stale @ts-ignore.