### PR TITLE
Fix serving assets from paths containing dot directories

### DIFF
--- a/packages/react-cosmos/src/corePlugins/pluginEndpointPlugin.ts
+++ b/packages/react-cosmos/src/corePlugins/pluginEndpointPlugin.ts
@@ -1,6 +1,7 @@
 import path from 'node:path';
 import type { Request, Response } from 'express';
 import type { CosmosServerPlugin } from '../cosmosPlugin/types.js';
+import { sendFile } from '../shared/sendFile.js';
 import { resolveSilent } from '../utils/resolveSilent.js';
 
 export const pluginEndpointPlugin: CosmosServerPlugin = {
@@ -26,7 +27,7 @@ export const pluginEndpointPlugin: CosmosServerPlugin = {
         return;
       }
 
-      res.sendFile(resolvedPath);
+      sendFile(res, resolvedPath);
     });
   },
 };

--- a/packages/react-cosmos/src/devServer/__tests__/devServerUiPlugin.ts
+++ b/packages/react-cosmos/src/devServer/__tests__/devServerUiPlugin.ts
@@ -19,10 +19,23 @@ const port = 5000 + viteWorkerId();
 const testFsPath = path.join(__dirname, '../__testFs__');
 const pluginPath = path.join(testFsPath, `plugin-${viteWorkerId()}`);
 
+// Package managers like pnpm resolve modules inside a dot directory
+const dotPluginPath = path.join(
+  testFsPath,
+  '.pnpm',
+  `plugin-${viteWorkerId()}`
+);
+
 const testCosmosPlugin = {
   name: 'Test Cosmos plugin',
   rootDir: pluginPath,
   ui: path.join(pluginPath, 'ui.js'),
+};
+
+const testCosmosDotPlugin = {
+  name: 'Test Cosmos dot plugin',
+  rootDir: dotPluginPath,
+  ui: path.join(dotPluginPath, 'ui.js'),
 };
 
 let _stopServer: (() => Promise<unknown>) | undefined;
@@ -33,14 +46,18 @@ beforeAll(async () => {
     rootDir: testFsPath,
     port,
   });
-  await mockCosmosPlugins([testCosmosPlugin]);
+  await mockCosmosPlugins([testCosmosPlugin, testCosmosDotPlugin]);
 
-  await fs.mkdir(testCosmosPlugin.rootDir, { recursive: true });
-  await fs.writeFile(testCosmosPlugin.ui, 'export {}', 'utf8');
+  for (const plugin of [testCosmosPlugin, testCosmosDotPlugin]) {
+    await fs.mkdir(plugin.rootDir, { recursive: true });
+    await fs.writeFile(plugin.ui, 'export {}', 'utf8');
+  }
 
   await mockConsole(async ({ expectLog }) => {
     expectLog('[Cosmos] Using config found at cosmos.config.json');
-    expectLog('[Cosmos] Found 1 plugin: Test Cosmos plugin');
+    expectLog(
+      '[Cosmos] Found 2 plugins: Test Cosmos plugin, Test Cosmos dot plugin'
+    );
     expectLog(
       `[Cosmos] See you at http://localhost:${port} or http://192.168.1.10:${port}`
     );
@@ -52,6 +69,7 @@ beforeAll(async () => {
 afterAll(async () => {
   await _stopServer!();
   await fs.rm(pluginPath, { recursive: true, force: true });
+  await fs.rm(dotPluginPath, { recursive: true, force: true });
 });
 
 it('embeds plugin in playground HTML', async () => {
@@ -59,17 +77,32 @@ it('embeds plugin in playground HTML', async () => {
   expect(res.status).toBe(200);
 
   const html = await res.text();
-  expect(html).toContain(JSON.stringify([testCosmosPlugin]));
+  expect(html).toContain(
+    JSON.stringify([testCosmosPlugin, testCosmosDotPlugin])
+  );
 });
 
 it('serves plugin JS files', async () => {
-  // Windows paths don't start with a slash (e.g. C:\foo\bar.js)
-  const uiPath = testCosmosPlugin.ui.startsWith('/')
-    ? testCosmosPlugin.ui
-    : `/${testCosmosPlugin.ui}`;
-  const res = await fetch(`http://localhost:${port}/_plugin${uiPath}`);
+  const res = await fetch(
+    `http://localhost:${port}/_plugin${pluginUrlPath(testCosmosPlugin.ui)}`
+  );
   expect(res.status).toBe(200);
 
   const uiJs = await res.text();
   expect(uiJs).toBe('export {}');
 });
+
+it('serves plugin JS files from dot directories', async () => {
+  const res = await fetch(
+    `http://localhost:${port}/_plugin${pluginUrlPath(testCosmosDotPlugin.ui)}`
+  );
+  expect(res.status).toBe(200);
+
+  const uiJs = await res.text();
+  expect(uiJs).toBe('export {}');
+});
+
+function pluginUrlPath(uiPath: string) {
+  // Windows paths don't start with a slash (e.g. C:\foo\bar.js)
+  return uiPath.startsWith('/') ? uiPath : `/${uiPath}`;
+}

--- a/packages/react-cosmos/src/devServer/expressApp.ts
+++ b/packages/react-cosmos/src/devServer/expressApp.ts
@@ -4,6 +4,7 @@ import type { CosmosPluginConfig } from 'react-cosmos-core';
 import type { CosmosConfig } from '../cosmosConfig/types.js';
 import type { CosmosPlatform } from '../cosmosPlugin/types.js';
 import { getDevPlaygroundHtml } from '../shared/playgroundHtml.js';
+import { sendFile } from '../shared/sendFile.js';
 import { getStaticPath } from '../shared/staticPath.js';
 import { resolve } from '../utils/resolve.js';
 
@@ -19,15 +20,15 @@ export async function createExpressApp(
   });
 
   app.get('/playground.bundle.js', (_: Request, res: Response) => {
-    res.sendFile(resolve('react-cosmos-ui/dist/playground.bundle.js'));
+    sendFile(res, resolve('react-cosmos-ui/dist/playground.bundle.js'));
   });
 
   app.get('/playground.bundle.js.map', (_: Request, res: Response) => {
-    res.sendFile(resolve('react-cosmos-ui/dist/playground.bundle.js.map'));
+    sendFile(res, resolve('react-cosmos-ui/dist/playground.bundle.js.map'));
   });
 
   app.get('/_cosmos.ico', (_: Request, res: Response) => {
-    res.sendFile(getStaticPath('favicon.ico'));
+    sendFile(res, getStaticPath('favicon.ico'));
   });
 
   return app;

--- a/packages/react-cosmos/src/shared/sendFile.ts
+++ b/packages/react-cosmos/src/shared/sendFile.ts
@@ -1,0 +1,10 @@
+import path from 'node:path';
+import type { Response } from 'express';
+
+// Express 5 (send >= 1) responds with 404 when any segment of the served path
+// is a dotfile, and package managers like pnpm resolve modules inside a .pnpm
+// directory. Sending the file name relative to its own directory keeps the
+// dotfile check scoped to the file itself, which is what we serve anyway.
+export function sendFile(res: Response, filePath: string) {
+  res.sendFile(path.basename(filePath), { root: path.dirname(filePath) });
+}


### PR DESCRIPTION
Express 5 (send >= 1) responds with 404 when any segment of the served path is a dotfile. Package managers like pnpm resolve modules inside a .pnpm directory, so every res.sendFile call with an absolute path 404'd: the playground bundle, its sourcemap, the favicon and UI plugin modules.

Send the file name relative to its own directory instead, which scopes the dotfile check to the file we actually serve rather than to wherever the package happens to live on disk.

Fixes #1771